### PR TITLE
Add the ability to hard-code the user's lat/long locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,3 +11,15 @@ var config = {
     MAPS_KEY: 'your-google-maps-api-key'
 };
 ```
+
+If you want to run the site locally without HTTPS and at a non-localhost URL,
+you can also add in a `LOCAL_DEV_LAT_LNG` item to hard-code your location to
+some latitude and longitude:
+
+```
+var config = {
+    ...
+    LOCAL_DEV_LAT_LNG: {lat: 12.345, lng: 67.890}
+    ...
+}
+```

--- a/src/main/webapp/homepage_script.js
+++ b/src/main/webapp/homepage_script.js
@@ -187,7 +187,7 @@ function getUserNeighborhood() {
                     if (config.LOCAL_DEV_LAT_LONG) {
                         resolve(config.LOCAL_DEV_LAT_LONG);
                     } else {
-                        reject ("User location failed");
+                        reject("User location failed");
                     }
                 } else {
                     reject("User location failed");

--- a/src/main/webapp/homepage_script.js
+++ b/src/main/webapp/homepage_script.js
@@ -186,6 +186,8 @@ function getUserNeighborhood() {
                 if (err.code === 1 && !window.isSecureContext) {
                     if (config.LOCAL_DEV_LAT_LONG) {
                         resolve(config.LOCAL_DEV_LAT_LONG);
+                    } else {
+                        reject ("User location failed");
                     }
                 } else {
                     reject("User location failed");

--- a/src/main/webapp/homepage_script.js
+++ b/src/main/webapp/homepage_script.js
@@ -179,8 +179,17 @@ function getUserNeighborhood() {
             navigator.geolocation.getCurrentPosition(function(position) {
                 var location = {lat: position.coords.latitude, lng: position.coords.longitude};
                 resolve(location);
-            }, function() {
-                reject("User location failed");
+            }, function(err) {
+                // Check to see if this failed because we're in an insecure
+                // context, such as a local dev environment that isn't
+                // http://localhost (https://developer.mozilla.org/en-US/docs/Web/Security/Secure_Contexts).
+                if (err.code === 1 && !window.isSecureContext) {
+                    if (config.LOCAL_DEV_LAT_LONG) {
+                        resolve(config.LOCAL_DEV_LAT_LONG);
+                    }
+                } else {
+                    reject("User location failed");
+                }
             });
         } else {
             reject("User location is not supported by this browser");


### PR DESCRIPTION
This helps developers and reviewers test the site in a local context
when the URL isn't http://localhost, such as when using the Linux
container on a Chromebook. The geolocation API isn't available in these
insecure contexts, so this change allows us to bypass that and continue
testing the site.