### PR TITLE
Fix typo: LOCAL_DEV_LAT_LONG -> LOCAL_DEV_LAT_LNG

### DIFF
--- a/src/main/webapp/homepage_script.js
+++ b/src/main/webapp/homepage_script.js
@@ -184,8 +184,8 @@ function getUserLocation() {
                 // context, such as a local dev environment that isn't
                 // http://localhost (https://developer.mozilla.org/en-US/docs/Web/Security/Secure_Contexts).
                 if (err.code === 1 && !window.isSecureContext) {
-                    if (config.LOCAL_DEV_LAT_LONG) {
-                        resolve(config.LOCAL_DEV_LAT_LONG);
+                    if (config.LOCAL_DEV_LAT_LNG) {
+                        resolve(config.LOCAL_DEV_LAT_LNG);
                     } else {
                         reject("User location failed");
                     }


### PR DESCRIPTION
The docs say the latter, but the code says the former. Should have fixed this in #45.