### PR TITLE
implement pagination when listing tasks in the homepage

### DIFF
--- a/src/main/java/com/google/neighborgood/helper/TaskList.java
+++ b/src/main/java/com/google/neighborgood/helper/TaskList.java
@@ -1,0 +1,113 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.neighborgood.helper;
+
+import com.google.appengine.api.datastore.DatastoreService;
+import com.google.appengine.api.datastore.DatastoreServiceFactory;
+import com.google.appengine.api.datastore.Entity;
+import com.google.appengine.api.datastore.EntityNotFoundException;
+import com.google.appengine.api.datastore.Key;
+import com.google.appengine.api.datastore.KeyFactory;
+import com.google.appengine.api.users.UserService;
+import com.google.appengine.api.users.UserServiceFactory;
+import java.util.HashMap;
+
+public final class TaskList {
+
+  private static HashMap<String, String> usersNicknames;
+  private StringBuilder taskListString;
+  private boolean endOfResults;
+  private final boolean userLoggedIn;
+  private final String userId;
+  private static DatastoreService datastore;
+  private int pageCount;
+
+  public TaskList() {
+    this.usersNicknames = new HashMap<String, String>();
+    this.taskListString = new StringBuilder();
+    UserService userService = UserServiceFactory.getUserService();
+    this.userLoggedIn = userService.isUserLoggedIn();
+    this.userId = this.userLoggedIn ? userService.getCurrentUser().getUserId() : "null";
+    this.datastore = DatastoreServiceFactory.getDatastoreService();
+    this.endOfResults = false;
+    this.pageCount = 1;
+  }
+
+  public void addTask(Entity entity) {
+    taskListString
+        .append("<div class='task' data-key='")
+        .append(KeyFactory.keyToString(entity.getKey()))
+        .append("'>");
+    if (this.userLoggedIn) {
+      taskListString.append("<div class='help-overlay'>");
+      taskListString.append("<div class='exit-help'><a>&times</a></div>");
+      taskListString.append("<a class='confirm-help'>CONFIRM</a>");
+      taskListString.append("</div>");
+    }
+    taskListString.append("<div class='task-container'>");
+    taskListString.append("<div class='task-header'>");
+    taskListString.append("<div class='user-nickname'>");
+
+    // Checks if tasks's user nickname has already been retrieved,
+    // otherwise retrieves it and temporarily stores it
+    String taskOwner = (String) entity.getProperty("Owner");
+    if (this.usersNicknames.containsKey(taskOwner)) {
+      taskListString.append(this.usersNicknames.get(taskOwner));
+    } else {
+      Key taskOwnerKey = entity.getParent();
+      try {
+        Entity userEntity = datastore.get(taskOwnerKey);
+        String userNickname = (String) userEntity.getProperty("nickname");
+        this.usersNicknames.put(taskOwner, userNickname);
+        taskListString.append(userNickname);
+      } catch (EntityNotFoundException e) {
+        System.err.println(
+            "Unable to find the task's owner info to retrieve the owner's nickname. Setting a default nickname.");
+        taskListString.append("Neighbor");
+      }
+    }
+    taskListString.append("</div>");
+    if (this.userLoggedIn) {
+      // changes the Help Button div if the current user is the owner of the task
+      if (!this.userId.equals(taskOwner)) {
+        taskListString.append("<div class='help-out'>HELP OUT</div>");
+      } else {
+        taskListString.append(
+            "<div class='help-out disable-help' title='This is your own task'>HELP OUT</div>");
+      }
+    }
+    taskListString.append("</div>");
+    taskListString
+        .append(
+            "<div class='task-content' onclick='showTaskInfo(\""
+                + KeyFactory.keyToString(entity.getKey())
+                + "\")'>")
+        .append((String) entity.getProperty("overview"))
+        .append("</div>");
+    taskListString
+        .append("<div class='task-footer'><div class='task-category'>#")
+        .append((String) entity.getProperty("category"))
+        .append("</div></div>");
+    taskListString.append("</div></div>");
+  }
+
+  public void setEndOfResults() {
+    this.endOfResults = true;
+  }
+
+  public void setPageCount(int pagecount) {
+    this.pageCount = pagecount;
+  }
+}

--- a/src/main/java/com/google/neighborgood/helper/TaskPages.java
+++ b/src/main/java/com/google/neighborgood/helper/TaskPages.java
@@ -25,14 +25,20 @@ import com.google.appengine.api.users.UserServiceFactory;
 import java.util.ArrayList;
 import java.util.HashMap;
 
+/**
+ * Helper class that stores the HTML depiction of tasks in groups of 10 per ArrayList index to
+ * assist with pagination
+ */
 public class TaskPages {
-  private static HashMap<String, String> usersNicknames;
+  private static HashMap<String, String>
+      usersNicknames; // Stores task owner's user info to prevent querying multiple times in
+  // datastore for the same user's info
   private static DatastoreService datastore;
   private final boolean userLoggedIn;
   private final String userId;
   private int pageCount;
   private int taskCount;
-  private StringBuilder page;
+  private StringBuilder page; // String-like representation of a page's worth of tasks
   private ArrayList<String> taskPages;
 
   public TaskPages() {
@@ -47,9 +53,11 @@ public class TaskPages {
     this.pageCount = 0;
   }
 
+  /** addTask method adds a single task HTML string to the page variable */
   public void addTask(Entity entity) {
 
-    // starts new page if task count for current page reached 10 already
+    // adds current page to taskPages and starts new page if task count for current page reached 10
+    // already
     if (this.taskCount % 10 == 0 && this.taskCount != 0) {
       this.taskPages.add(page.toString());
       this.page = new StringBuilder();
@@ -112,6 +120,9 @@ public class TaskPages {
     this.taskCount++;
   }
 
+  /**
+   * If there are no more tasks to add, it adds the current/last page onto the taskPages ArrayList
+   */
   public void addLastPage() {
     this.taskPages.add(page.toString());
     this.pageCount++;

--- a/src/main/java/com/google/neighborgood/helper/TaskPages.java
+++ b/src/main/java/com/google/neighborgood/helper/TaskPages.java
@@ -22,6 +22,8 @@ import com.google.appengine.api.datastore.Key;
 import com.google.appengine.api.datastore.KeyFactory;
 import com.google.appengine.api.users.UserService;
 import com.google.appengine.api.users.UserServiceFactory;
+import java.sql.Timestamp;
+import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.HashMap;
 
@@ -105,16 +107,19 @@ public class TaskPages {
       }
     }
     page.append("</div>");
-    page.append(
-            "<div class='task-content' onclick='showTaskInfo(\""
-                + KeyFactory.keyToString(entity.getKey())
-                + "\")'>")
+    page.append("<div class='task-content'>")
         .append((String) entity.getProperty("overview"))
         .append("</div>");
     page.append("<div class='task-footer'><div class='task-category'>#")
         .append((String) entity.getProperty("category"))
-        .append("</div></div>");
-    page.append("</div></div>");
+        .append("</div>");
+
+    Timestamp timestamp = new Timestamp((Long) entity.getProperty("timestamp"));
+    SimpleDateFormat timestampFormat = new SimpleDateFormat("HH:mm MM-dd-yyyy");
+
+    page.append("<div class='task-date-time'>")
+        .append((String) timestampFormat.format(timestamp))
+        .append("</div></div></div></div>");
 
     this.taskCount++;
   }

--- a/src/main/java/com/google/neighborgood/helper/TaskPages.java
+++ b/src/main/java/com/google/neighborgood/helper/TaskPages.java
@@ -120,9 +120,10 @@ public class TaskPages {
   }
 
   /**
-   * If there are no more tasks to add, it adds the current/last page onto the taskPages ArrayList
+   * If there are no more tasks to add, this method can be used to add the current/last page onto
+   * the taskPages ArrayList
    */
-  public void addLastPage() {
+  public void endPages() {
     this.taskPages.add(page.toString());
     this.pageCount++;
   }

--- a/src/main/java/com/google/neighborgood/helper/TaskPages.java
+++ b/src/main/java/com/google/neighborgood/helper/TaskPages.java
@@ -57,7 +57,6 @@ public class TaskPages {
   public void addTask(Entity entity) {
 
     // adds current page to taskPages and starts new page if task count for current page reached 10
-    // already
     if (this.taskCount % 10 == 0 && this.taskCount != 0) {
       this.taskPages.add(page.toString());
       this.page = new StringBuilder();

--- a/src/main/java/com/google/neighborgood/helper/TaskPages.java
+++ b/src/main/java/com/google/neighborgood/helper/TaskPages.java
@@ -22,92 +22,98 @@ import com.google.appengine.api.datastore.Key;
 import com.google.appengine.api.datastore.KeyFactory;
 import com.google.appengine.api.users.UserService;
 import com.google.appengine.api.users.UserServiceFactory;
+import java.util.ArrayList;
 import java.util.HashMap;
 
-public final class TaskList {
-
+public class TaskPages {
   private static HashMap<String, String> usersNicknames;
-  private StringBuilder taskListString;
-  private boolean endOfResults;
+  private static DatastoreService datastore;
   private final boolean userLoggedIn;
   private final String userId;
-  private static DatastoreService datastore;
   private int pageCount;
+  private int taskCount;
+  private StringBuilder page;
+  private ArrayList<String> taskPages;
 
-  public TaskList() {
+  public TaskPages() {
     this.usersNicknames = new HashMap<String, String>();
-    this.taskListString = new StringBuilder();
     UserService userService = UserServiceFactory.getUserService();
     this.userLoggedIn = userService.isUserLoggedIn();
     this.userId = this.userLoggedIn ? userService.getCurrentUser().getUserId() : "null";
     this.datastore = DatastoreServiceFactory.getDatastoreService();
-    this.endOfResults = false;
-    this.pageCount = 1;
+    this.taskPages = new ArrayList<String>();
+    this.page = new StringBuilder();
+    this.taskCount = 0;
+    this.pageCount = 0;
   }
 
   public void addTask(Entity entity) {
-    taskListString
-        .append("<div class='task' data-key='")
+
+    // starts new page if task count for current page reached 10 already
+    if (this.taskCount % 10 == 0 && this.taskCount != 0) {
+      this.taskPages.add(page.toString());
+      this.page = new StringBuilder();
+      this.pageCount++;
+    }
+
+    page.append("<div class='task' data-key='")
         .append(KeyFactory.keyToString(entity.getKey()))
         .append("'>");
     if (this.userLoggedIn) {
-      taskListString.append("<div class='help-overlay'>");
-      taskListString.append("<div class='exit-help'><a>&times</a></div>");
-      taskListString.append("<a class='confirm-help'>CONFIRM</a>");
-      taskListString.append("</div>");
+      page.append("<div class='help-overlay'>");
+      page.append("<div class='exit-help'><a>&times</a></div>");
+      page.append("<a class='confirm-help'>CONFIRM</a>");
+      page.append("</div>");
     }
-    taskListString.append("<div class='task-container'>");
-    taskListString.append("<div class='task-header'>");
-    taskListString.append("<div class='user-nickname'>");
+    page.append("<div class='task-container'>");
+    page.append("<div class='task-header'>");
+    page.append("<div class='user-nickname'>");
 
     // Checks if tasks's user nickname has already been retrieved,
     // otherwise retrieves it and temporarily stores it
     String taskOwner = (String) entity.getProperty("Owner");
     if (this.usersNicknames.containsKey(taskOwner)) {
-      taskListString.append(this.usersNicknames.get(taskOwner));
+      page.append(this.usersNicknames.get(taskOwner));
     } else {
       Key taskOwnerKey = entity.getParent();
       try {
-        Entity userEntity = datastore.get(taskOwnerKey);
+        Entity userEntity = this.datastore.get(taskOwnerKey);
         String userNickname = (String) userEntity.getProperty("nickname");
         this.usersNicknames.put(taskOwner, userNickname);
-        taskListString.append(userNickname);
+        page.append(userNickname);
       } catch (EntityNotFoundException e) {
         System.err.println(
             "Unable to find the task's owner info to retrieve the owner's nickname. Setting a default nickname.");
-        taskListString.append("Neighbor");
+        page.append("Neighbor");
       }
     }
-    taskListString.append("</div>");
+    page.append("</div>");
     if (this.userLoggedIn) {
       // changes the Help Button div if the current user is the owner of the task
       if (!this.userId.equals(taskOwner)) {
-        taskListString.append("<div class='help-out'>HELP OUT</div>");
+        page.append("<div class='help-out'>HELP OUT</div>");
       } else {
-        taskListString.append(
+        page.append(
             "<div class='help-out disable-help' title='This is your own task'>HELP OUT</div>");
       }
     }
-    taskListString.append("</div>");
-    taskListString
-        .append(
+    page.append("</div>");
+    page.append(
             "<div class='task-content' onclick='showTaskInfo(\""
                 + KeyFactory.keyToString(entity.getKey())
                 + "\")'>")
         .append((String) entity.getProperty("overview"))
         .append("</div>");
-    taskListString
-        .append("<div class='task-footer'><div class='task-category'>#")
+    page.append("<div class='task-footer'><div class='task-category'>#")
         .append((String) entity.getProperty("category"))
         .append("</div></div>");
-    taskListString.append("</div></div>");
+    page.append("</div></div>");
+
+    this.taskCount++;
   }
 
-  public void setEndOfResults() {
-    this.endOfResults = true;
-  }
-
-  public void setPageCount(int pagecount) {
-    this.pageCount = pagecount;
+  public void addLastPage() {
+    this.taskPages.add(page.toString());
+    this.pageCount++;
   }
 }

--- a/src/main/java/com/google/neighborgood/servlets/TaskServlet.java
+++ b/src/main/java/com/google/neighborgood/servlets/TaskServlet.java
@@ -110,7 +110,7 @@ public class TaskServlet extends HttpServlet {
       taskPages.addTask(entity);
     }
 
-    taskPages.addLastPage();
+    taskPages.endPages();
 
     Gson gson = new Gson();
     String json = gson.toJson(taskPages);

--- a/src/main/java/com/google/neighborgood/servlets/TaskServlet.java
+++ b/src/main/java/com/google/neighborgood/servlets/TaskServlet.java
@@ -99,10 +99,8 @@ public class TaskServlet extends HttpServlet {
     query.setFilter(new Query.CompositeFilter(Query.CompositeFilterOperator.AND, filters));
 
     // limits results to the 100 most recent tasks that will be queried once and distributed among
-    // 10 pages.
-    // Ideally 10 results would be queried each time there was a page change using Cursors, however
-    // cursors are not
-    // supported with geo-spatial queries.
+    // 10 pages. Ideally 10 results would be queried each time there was a page change using
+    // Cursors, however cursors are not supported with geo-spatial queries.
     List<Entity> results = datastore.prepare(query).asList(FetchOptions.Builder.withLimit(100));
 
     TaskPages taskPages = new TaskPages();

--- a/src/main/webapp/homepage_script.js
+++ b/src/main/webapp/homepage_script.js
@@ -16,6 +16,8 @@ const MAPSKEY = config.MAPS_KEY
 let userLocation = null;
 let currentCategory = "all";
 let currentMiles = 5;
+let currentPage = 1;
+let taskListPagesCache = new Map();
 
 window.onscroll = stickyControlBar;
 
@@ -75,7 +77,23 @@ function addUIClickHandlers() {
         fetchTasks(currentCategory, e.target.value)
             .then(response => displayTasks(response));
     });
+
+    // adds nextPage and prevPage click events
+    document.getElementById("prev-page").addEventListener("click", prevPage);
+    //document.getElementById("next-page").addEventListener("click", nextPage);
 }
+
+/* Function loads previous page of tasks */
+function prevPage() {
+    if (currentPage > 1) {
+        currentPage--;
+        if (taskListPagesCache.has(currentPage - 1)) {
+            displayTasks(taskListPagesCache.get(currentPage - 1));
+        } 
+    }
+}
+
+/* Function loads next page of tasks */
 
 /* Function filters tasks by categories and styles selected categories */
 function filterTasksBy(category) {
@@ -321,24 +339,23 @@ function fetchTasks(category, miles) {
     if (category !== undefined && category != "all") {
         url += "&category=" + category;
     }
-    return fetch(url);
+    return fetch(url).then(response => response.json());
 }
 
 /* Displays the tasks received from the server response */
-function displayTasks(response) {
-    response.json().then(html => {
-        if (html){
-            document.getElementById("no-tasks-message").style.display = "none";
-            document.getElementById("tasks-message").style.display = "block";
-            document.getElementById("tasks-list").innerHTML = html;
-            document.getElementById("tasks-list").style.display = "block";
-            addTasksClickHandlers();
-        } else {
-            document.getElementById("no-tasks-message").style.display = "block";
-            document.getElementById("tasks-message").style.display = "none";
-            document.getElementById("tasks-list").style.display = "none";
-        }
-    });
+function displayTasks(taskList) {
+    if (taskList.taskListString) {
+        document.getElementById("no-tasks-message").style.display = "none";
+        document.getElementById("tasks-message").style.display = "block";
+        document.getElementById("tasks-list").innerHTML = taskList.taskListString;
+        document.getElementById("tasks-list").style.display = "block";
+        addTasksClickHandlers();
+    } else {
+        document.getElementById("no-tasks-message").style.display = "block";
+        document.getElementById("tasks-message").style.display = "none";
+        document.getElementById("tasks-list").style.display = "none";
+    }
+    
 }
 
 /* Function adds all the necessary tasks 'click' event listeners*/

--- a/src/main/webapp/homepage_script.js
+++ b/src/main/webapp/homepage_script.js
@@ -18,6 +18,7 @@ let currentCategory = "all";
 let currentMiles = 5;
 let currentPage = 1;
 let taskPagesCache = null;
+let currentPageNumberNode = null;
 
 //window.onscroll = stickyControlBar;
 
@@ -98,6 +99,7 @@ function prevPage() {
             nextPageButton.style.cursor = "pointer";
             nextPageButton.removeAttribute("title");
         }
+        displayPaginationUI();
     } 
 }
 
@@ -113,6 +115,7 @@ function nextPage() {
             nextPageButton.style.cursor = "not-allowed";
             nextPageButton.setAttribute("title", "You are already on the last page");
         }
+        displayPaginationUI();
     }
 }
 
@@ -365,10 +368,26 @@ function fetchTasks(category, miles) {
 /* Displays the tasks received from the server response */
 function displayTasks(response) {
 
-    // If a response is passed, the the taskPagesCache is updated along with the next and prev page button styles
+    // If a response is passed, the the taskPagesCache is updated along with the next and prev page buttons 
     if (response !== undefined) {
         taskPagesCache = response;
-        let nextPageButton = document.getElementById("next-page");
+        displayPaginationUI();
+    }
+    if (taskPagesCache !== null && taskPagesCache.taskCount > 0) {
+        document.getElementById("no-tasks-message").style.display = "none";
+        document.getElementById("tasks-message").style.display = "block";
+        document.getElementById("tasks-list").innerHTML = taskPagesCache.taskPages[currentPage - 1];
+        document.getElementById("tasks-list").style.display = "block";
+        addTasksClickHandlers();
+    } else {
+        document.getElementById("no-tasks-message").style.display = "block";
+        document.getElementById("tasks-message").style.display = "none";
+        document.getElementById("tasks-list").style.display = "none";
+    }
+}
+
+function displayPaginationUI() {
+    let nextPageButton = document.getElementById("next-page");
         let prevPageButton = document.getElementById("prev-page");
         if (taskPagesCache.pageCount > 1) {
             nextPageButton.style.cursor = "pointer";
@@ -388,18 +407,66 @@ function displayTasks(response) {
             prevPageButton.style.cursor = "not-allowed";
             prevPageButton.setAttribute("title", "You are already on the first page");
         }
-    }
-    if (taskPagesCache !== null && taskPagesCache.taskCount > 0) {
-        document.getElementById("no-tasks-message").style.display = "none";
-        document.getElementById("tasks-message").style.display = "block";
-        document.getElementById("tasks-list").innerHTML = taskPagesCache.taskPages[currentPage - 1];
-        document.getElementById("tasks-list").style.display = "block";
-        addTasksClickHandlers();
+
+    let pageNumbersWrapper = document.getElementById("page-numbers-wrapper");
+    pageNumbersWrapper.innerHTML = "";
+    if (taskPagesCache.pageCount <= 5 || (window.innerWidth >= 375)) {
+        for (let i = 1; i <= taskPagesCache.pageCount; i++) {
+            let pageNumber = document.createElement("a");
+            pageNumber.classList.add("page-number");
+            if (i === currentPage) pageNumber.setAttribute("id", "current-page");
+            pageNumber.innerText = i;
+            pageNumber.addEventListener("click", function() {
+                currentPageNumberNode.removeAttribute("id");
+                currentPageNumberNode = pageNumber;
+                currentPage = i;
+                pageNumber.setAttribute("id", "current-page");
+                displayTasks();
+            });
+            pageNumbersWrapper.appendChild(pageNumber);
+        }
     } else {
-        document.getElementById("no-tasks-message").style.display = "block";
-        document.getElementById("tasks-message").style.display = "none";
-        document.getElementById("tasks-list").style.display = "none";
+        let pageNumberSpacing = document.createElement("div");
+        pageNumberSpacing.classList.add("page-number-spacing");
+        pageNumberSpacing.innerText = "...";
+
+        if (currentPage !== 1) {
+            let firstPageNumber = document.createElement("a");
+            firstPageNumber.classList.add("page-number");
+            firstPageNumber.innerText = 1;
+            firstPageNumber.addEventListener("click", function() {
+                    currentPageNumberNode.removeAttribute("id");
+                    currentPageNumberNode = pageNumber;
+                    currentPage = 1;
+                    pageNumber.setAttribute("id", "current-page");
+                    displayTasks();
+                });
+            pageNumbersWrapper.appendChild(firstPageNumber);
+            pageNumbersWrapper.appendChild(pageNumberSpacing);
+        }
+
+        let currentPageNumber = document.createElement("a");
+        currentPageNumber.classList.add("page-number");
+        currentPageNumber.setAttribute("id", "current-page");
+        currentPageNumber.innerText = currentPage;
+        pageNumbersWrapper.appendChild(currentPageNumber);
+
+        if (currentPage != taskPagesCache.pageCount) {
+            pageNumbersWrapper.appendChild(pageNumberSpacing.cloneNode(true));
+            let lastPageNumber = document.createElement("a");
+            lastPageNumber.classList.add("page-number");
+            lastPageNumber.innerText = taskPagesCache.pageCount;
+            lastPageNumber.addEventListener("click", function() {
+                    currentPageNumberNode.removeAttribute("id");
+                    currentPageNumberNode = lastPageNumber;
+                    lastPageNumber.setAttribute("id", "current-page");
+                    currentPage = taskPagesCache.pageCount;
+                    displayTasks();
+                });
+            pageNumbersWrapper.appendChild(lastPageNumber);
+        }
     }
+    currentPageNumberNode = document.getElementById("current-page");
 }
 
 /* Function adds all the necessary tasks 'click' event listeners*/

--- a/src/main/webapp/homepage_script.js
+++ b/src/main/webapp/homepage_script.js
@@ -21,6 +21,7 @@ let taskPagesCache = null;
 let currentPageNumberNode = null;
 
 window.addEventListener("resize", displayPaginationUI);
+window.addEventListener("resize", window.onscroll);
 
 window.onscroll = function() {
     if (window.innerWidth >= 1204) {

--- a/src/main/webapp/homepage_script.js
+++ b/src/main/webapp/homepage_script.js
@@ -365,7 +365,7 @@ function fetchTasks(category, miles) {
 
 /* Displays the tasks received from the server response */
 function displayTasks(response) {
-    // If a response is passed, the the taskPagesCache is updated along with the next and prev page buttons 
+    // If a response is passed, the the taskPagesCache is updated
     if (response !== undefined) {
         taskPagesCache = response;
         // If displayTasks is called and the result has less pages than the page user was last at, the currentPage will get reset to 1

--- a/src/main/webapp/homepage_style.css
+++ b/src/main/webapp/homepage_style.css
@@ -153,22 +153,45 @@ section {
 }
 
 .pagination-icon {
-    cursor: not-allowed;
-    font-size: 2em;
-    font-weight: bold;
-    line-height: 0.8em;
-    padding: 0 0.5em;
+  cursor: not-allowed;
+  font-size: 2em;
+  font-weight: bold;
+  line-height: 0.8em;
+  padding: 0 0.2em;
 }
 
 .pagination-icon:hover {
-    color: gray;
+  color: gray;
+}
+
+.page-number {
+    font-weight: normal;
+}
+
+#current-page {
+    font-weight: bold;
+    cursor: default;
+}
+
+#current-page:hover {
+    color: #222;
 }
 
 #pagination-wrapper {
-    display: flex;
-    justify-content: space-between;
-    width: fit-content;
-    margin: auto;
+  display: flex;
+  justify-content: space-between;
+  width: fit-content;
+  margin: auto;
+}
+
+#page-numbers-wrapper {
+  display: flex;
+  justify-content: space-between;
+  line-height: 1.7em;
+}
+
+.page-number {
+  margin: 0 0.5em;
 }
 
 /* Tasks Styling */

--- a/src/main/webapp/homepage_style.css
+++ b/src/main/webapp/homepage_style.css
@@ -161,6 +161,19 @@ section {
   font-size: 3.5em;
 }
 
+#pagination-wrapper {
+  display: flex;
+  justify-content: space-between;
+  width: fit-content;
+  margin: auto;
+}
+
+#page-numbers-wrapper {
+  display: flex;
+  justify-content: space-between;
+  line-height: 1.7em;
+}
+
 .pagination-icon {
   cursor: not-allowed;
   font-size: 2em;
@@ -185,19 +198,6 @@ section {
 
 #current-page:hover {
   color: #222;
-}
-
-#pagination-wrapper {
-  display: flex;
-  justify-content: space-between;
-  width: fit-content;
-  margin: auto;
-}
-
-#page-numbers-wrapper {
-  display: flex;
-  justify-content: space-between;
-  line-height: 1.7em;
 }
 
 /* Tasks Styling */

--- a/src/main/webapp/homepage_style.css
+++ b/src/main/webapp/homepage_style.css
@@ -395,6 +395,16 @@ td {
   padding-bottom: 2em;
 }
 
+.highlight {
+  box-shadow: 0 0 5px rgba(255, 0, 0, 1);
+  border: 4px solid rgb(255, 0, 0);
+}
+
+.req {
+  margin: 2px;
+  color: red;
+}
+
 @media only screen and (max-width: 600px) {
   #title {
     font-size: 2.5em;
@@ -485,14 +495,4 @@ td {
   nav {
     background-color: white;
   }
-}
-
-.highlight {
-  box-shadow: 0 0 5px rgba(255, 0, 0, 1);
-  border: 4px solid rgb(255, 0, 0);
-}
-
-.req {
-  margin: 2px;
-  color: red;
 }

--- a/src/main/webapp/homepage_style.css
+++ b/src/main/webapp/homepage_style.css
@@ -153,11 +153,22 @@ section {
 }
 
 .pagination-icon {
-    cursor: pointer;
+    cursor: not-allowed;
+    font-size: 2em;
+    font-weight: bold;
+    line-height: 0.8em;
+    padding: 0 0.5em;
 }
 
-#prev-page {
-    cursor: not-allowed;
+.pagination-icon:hover {
+    color: gray;
+}
+
+#pagination-wrapper {
+    display: flex;
+    justify-content: space-between;
+    width: fit-content;
+    margin: auto;
 }
 
 /* Tasks Styling */

--- a/src/main/webapp/homepage_style.css
+++ b/src/main/webapp/homepage_style.css
@@ -174,16 +174,17 @@ section {
 }
 
 .page-number {
-    font-weight: normal;
+  font-weight: normal;
+  margin: 0 0.5em;
 }
 
 #current-page {
-    font-weight: bold;
-    cursor: default;
+  font-weight: bold;
+  cursor: default;
 }
 
 #current-page:hover {
-    color: #222;
+  color: #222;
 }
 
 #pagination-wrapper {
@@ -197,10 +198,6 @@ section {
   display: flex;
   justify-content: space-between;
   line-height: 1.7em;
-}
-
-.page-number {
-  margin: 0 0.5em;
 }
 
 /* Tasks Styling */

--- a/src/main/webapp/homepage_style.css
+++ b/src/main/webapp/homepage_style.css
@@ -152,6 +152,14 @@ section {
   font-size: 3.5em;
 }
 
+.pagination-icon {
+    cursor: pointer;
+}
+
+#prev-page {
+    cursor: not-allowed;
+}
+
 /* Tasks Styling */
 .results-message {
   display: none;

--- a/src/main/webapp/index.jsp
+++ b/src/main/webapp/index.jsp
@@ -143,7 +143,7 @@
       <!--Create Tasks Modal-->
       <div class="modalWrapper" id="createTaskModalWrapper">
         <div class="modal" id="createTaskModal">
-            <span class="close-button" id="close-addtask-button" onclick="closeCreateTaskModal()">&times;</span>
+            <span class="close-button" id="close-addtask-button">&times;</span>
             <form id="new-task-form" action="/tasks" method="POST" onsubmit="return validateTaskForm('new-task-form')">
                 <h1>CREATE A NEW TASK: </h1>
                 <div>

--- a/src/main/webapp/index.jsp
+++ b/src/main/webapp/index.jsp
@@ -127,7 +127,7 @@
                   </div>
                   <div id="pagination-wrapper">
                   <div id="prev-page" class="pagination-icon" title="You are already on the first page">&#8249;</div>
-                  <div id="page-numbers"></div>
+                  <div id="page-numbers-wrapper"></div>
                   <div id="next-page" class="pagination-icon" title="You are already on the last page">&#8250;</div>
                   </div
               </div>

--- a/src/main/webapp/index.jsp
+++ b/src/main/webapp/index.jsp
@@ -126,10 +126,10 @@
                         </select>
                   </div>
                   <div id="pagination-wrapper">
-                  <div id="prev-page" class="pagination-icon" title="You are already on the first page">&#8249;</div>
-                  <div id="page-numbers-wrapper"></div>
-                  <div id="next-page" class="pagination-icon" title="You are already on the last page">&#8250;</div>
-                  </div
+                        <div id="prev-page" class="pagination-icon" title="You are already on the first page">&#8249;</div>
+                        <div id="page-numbers-wrapper"></div>
+                        <div id="next-page" class="pagination-icon" title="You are already on the last page">&#8250;</div>
+                  </div>
               </div>
               <div id="no-tasks-message" class="results-message">
                   Sorry, there are currently no tasks within your neighborhood for you to help with.

--- a/src/main/webapp/index.jsp
+++ b/src/main/webapp/index.jsp
@@ -112,6 +112,8 @@
               </div>
               <div id="tasks-message" class="results-message">
                   These are the 20 (or less) most recent tasks in your neighborhood:
+                  <div id="tasks-list-wrapper">
+                  <div id="prev-page" class="pagination-icon">&#8249;</div>
                   <!-- Distance Options -->
                   <div id="distance-radius-div">
                         <label for="distance-radius">Show results within a radius of:</label>
@@ -125,6 +127,8 @@
                             <option value="50">50 miles</option>
                         </select>
                   </div>
+                  <div id="next-page" class="pagination-icon">&#8250;</div>
+                  </div
               </div>
               <div id="no-tasks-message" class="results-message">
                   Sorry, there are currently no tasks within your neighborhood for you to help with.

--- a/src/main/webapp/index.jsp
+++ b/src/main/webapp/index.jsp
@@ -112,8 +112,6 @@
               </div>
               <div id="tasks-message" class="results-message">
                   These are the 20 (or less) most recent tasks in your neighborhood:
-                  <div id="tasks-list-wrapper">
-                  <div id="prev-page" class="pagination-icon">&#8249;</div>
                   <!-- Distance Options -->
                   <div id="distance-radius-div">
                         <label for="distance-radius">Show results within a radius of:</label>
@@ -127,7 +125,10 @@
                             <option value="50">50 miles</option>
                         </select>
                   </div>
-                  <div id="next-page" class="pagination-icon">&#8250;</div>
+                  <div id="pagination-wrapper">
+                  <div id="prev-page" class="pagination-icon" title="You are already on the first page">&#8249;</div>
+                  <div id="page-numbers"></div>
+                  <div id="next-page" class="pagination-icon" title="You are already on the last page">&#8250;</div>
                   </div
               </div>
               <div id="no-tasks-message" class="results-message">


### PR DESCRIPTION
Resolves #30 

(I am awaiting for PR #91 to be merged into master to merge those changes into this branch - while these changes aren't merged, the homepage will have some glitchy behavior on smaller screens and in the meantime I have disabled the scrolling behavior)

While pagination would have been ideally implemented with the use of Cursors in Datastore, cursors are not supported for geo-spatial queries and therefore I had to come up with a workaround to make pagination less inefficient without the use of cursors. My current implementation queries up to 100 tasks at  the most on the first page load (or any time the page refreshes, gets filtered by distance or category), and stores all the tasks on the client-side, but only shows 10 at the time. That way when the user goes through the pages, it won't need to query the tasks again, but it will just reference the already stored tasks.
This implementation means that the results are limited to 10 pages of 10 tasks each, which seems like a reasonable amount for our project.