### PR TITLE
add searchbox to load tasks by different neighborhood

### DIFF
--- a/src/main/webapp/homepage_script.js
+++ b/src/main/webapp/homepage_script.js
@@ -439,18 +439,18 @@ function fetchTasks(category, cursor) {
 function displayTasks(append) {
     if (taskGroup !== null && taskGroup.currentTaskCount > 0) {
         document.getElementById("no-tasks-message").style.display = "none";
-        document.getElementById("loading").style.display = "none";
         document.getElementById("tasks-message").style.display = "block";
         if (append) document.getElementById("tasks-list").innerHTML += taskGroup.tasks;
         else document.getElementById("tasks-list").innerHTML = taskGroup.tasks;
         document.getElementById("tasks-list").style.display = "block";
         addTasksClickHandlers();
     } else {
-        document.getElementById("loading").style.display = "none";
         document.getElementById("no-tasks-message").style.display = "block";
         document.getElementById("tasks-message").style.display = "none";
         document.getElementById("tasks-list").style.display = "none";
     }
+    document.getElementById("loading").style.display = "none";
+    document.getElementById("search-box").style.visibility = "visible";
 }
 
 /* Function adds all the necessary tasks 'click' event listeners*/

--- a/src/main/webapp/homepage_script.js
+++ b/src/main/webapp/homepage_script.js
@@ -318,15 +318,30 @@ begins the processes of retrieving the user's location*/
 function getTasksForUserLocation() {
     const script = document.createElement("script");
     script.type = "text/javascript";
-    script.src =  "https://maps.googleapis.com/maps/api/js?key=" + MAPSKEY + "&callback=initialize&language=en";
+    script.src =  "https://maps.googleapis.com/maps/api/js?key=" + MAPSKEY + "&callback=initialize&libraries=places&language=en";
     script.defer = true;
     script.async = true;
     document.head.appendChild(script);
-	
+
     // Once the Maps API script has dynamically loaded it gets the user location,
     // waits until it gets an answer updates the global userLoaction variable and then calls
     // fetchTasks and displayTasks
 	window.initialize = function () {
+        let placeAutocomplete = new google.maps.places.Autocomplete(document.getElementById("place-input"));
+        placeAutocomplete.setFields(['geometry']);
+        google.maps.event.addListener(placeAutocomplete, 'place_changed', function() {
+                let place = placeAutocomplete.getPlace();
+                userLocation = place.geometry.location.toJSON();
+                toNeighborhood(userLocation)
+                    .then(() => fetchTasks())
+                    .then(response => {
+                            displayTasks(response);
+                        })
+                    .catch(() => {
+                        console.error("User location and/or neighborhood could not be retrieved");
+                        document.getElementById("location-missing-message").style.display = "block";
+                    });
+              });
          getUserLocation().then(location => toNeighborhood(location))
         	.then(() => fetchTasks(currentCategory))
             .then(response => {

--- a/src/main/webapp/homepage_script.js
+++ b/src/main/webapp/homepage_script.js
@@ -330,11 +330,9 @@ function getTasksForUserLocation() {
                     userLocation = userActualLocation;
                 }
                 toNeighborhood(userLocation)
-                        .then(() => fetchTasks())
+                        .then(() => fetchTasks(currentCategory, "clear"))
                         .then(response => {
                                 taskGroup = response;
-                                startCursor = taskGroup.startCursor;
-                                endCursor = taskGroup.endCursor;
                                 displayTasks(response);
                             })
                         .catch(() => {

--- a/src/main/webapp/homepage_script.js
+++ b/src/main/webapp/homepage_script.js
@@ -333,7 +333,7 @@ function getTasksForUserLocation() {
                                 displayTasks(response);
                             })
                         .catch(() => {
-                            console.error("User location and/or neighborhood could not be retrieved");
+                            document.getElementById("loading").style.display = "none";
                             document.getElementById("location-missing-message").style.display = "block";
                         });
               });
@@ -344,7 +344,6 @@ function getTasksForUserLocation() {
                     displayTasks();
                 })
             .catch(() => {
-                console.error("User location and/or neighborhood could not be retrieved");
                 document.getElementById("loading").style.display = "none";
                 document.getElementById("location-missing-message").style.display = "block";
             });
@@ -435,7 +434,7 @@ function displayTasks(append) {
     if (taskGroup !== null && taskGroup.currentTaskCount > 0) {
         document.getElementById("no-tasks-message").style.display = "none";
         document.getElementById("tasks-message").style.display = "block";
-        if (append == true) document.getElementById("tasks-list").innerHTML += taskGroup.tasks;
+        if (append) document.getElementById("tasks-list").innerHTML += taskGroup.tasks;
         else document.getElementById("tasks-list").innerHTML = taskGroup.tasks;
         document.getElementById("tasks-list").style.display = "block";
         addTasksClickHandlers();

--- a/src/main/webapp/homepage_script.js
+++ b/src/main/webapp/homepage_script.js
@@ -313,12 +313,13 @@ function getTasksForUserLocation() {
     script.async = true;
     document.head.appendChild(script);
 
-    // Once the Maps API script has dynamically loaded it gets the user location,
-    // waits until it gets an answer updates the global userLoaction variable and then calls
-    // fetchTasks and displayTasks
 	window.initialize = function () {
+        // Once the Maps API script has dynamically loaded it initializes the place autocomplete searchbox
         let placeAutocomplete = new google.maps.places.Autocomplete(document.getElementById("place-input"));
+        // 'geometry' field specifies that returned data will include the place's viewport and lat/lng
         placeAutocomplete.setFields(['geometry']);
+
+        // listener will use the inputted place to retrieve and display tasks
         google.maps.event.addListener(placeAutocomplete, 'place_changed', function() {
                 let place = placeAutocomplete.getPlace();
                 if (place.geometry != undefined) {
@@ -337,6 +338,8 @@ function getTasksForUserLocation() {
                             document.getElementById("location-missing-message").style.display = "block";
                         });
               });
+        // Once the Maps API script has dynamically loaded it initializes it gets the user location,
+        // retrieves the neighborhood from the location coordinates, fetches the tasks, and displays them
          getUserLocation().then(location => toNeighborhood(location))
         	.then(() => fetchTasks(currentCategory, "clear"))
             .then(response => {

--- a/src/main/webapp/homepage_style.css
+++ b/src/main/webapp/homepage_style.css
@@ -429,9 +429,9 @@ td {
     margin-top: -0.5em;
   }
 
-  #place-input { 
+  #place-input {
     display: block;
-   } 
+  }
 
   .results-message {
     width: 95%;

--- a/src/main/webapp/homepage_style.css
+++ b/src/main/webapp/homepage_style.css
@@ -46,10 +46,7 @@ nav {
 }
 
 #login-logout {
-  padding-right: 1em;
   padding-top: 0.8em;
-  text-align: right;
-  width: calc(calc(100vw - 60em) / 2);
 }
 
 a {
@@ -85,6 +82,9 @@ i:hover {
 .login-messages {
   margin-top: 0;
   margin-bottom: 0.5em;
+  text-align: right;
+  padding-right: 1em;
+  width: calc(calc(100vw - 60em) / 2);
 }
 
 /* Main Content Styling */
@@ -380,11 +380,15 @@ td {
     width: auto;
   }
 
+  .login-messages {
+    width: auto;
+  }
+
   #control-bar {
     display: block;
     width: 95%;
     margin: auto;
-    padding-bottom: 0.7em;
+    padding-bottom: 0;
   }
 
   #categories {
@@ -417,6 +421,15 @@ td {
   #addtaskbutton {
     font-size: 2.5em;
   }
+
+  #search-box {
+    padding-top: 0;
+    margin-top: -0.5em;
+  }
+
+  #place-input { 
+    display: block;
+   } 
 
   .results-message {
     width: 95%;
@@ -457,6 +470,10 @@ td {
   #control-bar-message-wrapper {
     top: 80px;
     padding-top: 0;
+  }
+
+  .login-messages {
+    width: auto;
   }
 
   nav {

--- a/src/main/webapp/homepage_style.css
+++ b/src/main/webapp/homepage_style.css
@@ -100,7 +100,11 @@ section {
   margin: auto;
   max-width: 55em;
   justify-content: space-between;
-  padding-bottom: 1.5em;
+  padding-bottom: 0.5em;
+}
+
+#search-box {
+  padding: 0.5em 0.5em 1em 0.5em;
 }
 
 #control-bar-message-wrapper {

--- a/src/main/webapp/homepage_style.css
+++ b/src/main/webapp/homepage_style.css
@@ -105,6 +105,7 @@ section {
 
 #search-box {
   padding: 0.5em 0.5em 1em 0.5em;
+  visibility: hidden;
 }
 
 #control-bar-message-wrapper {
@@ -173,6 +174,7 @@ section {
 
 #loading {
   display: block;
+  margin-top: -2em;
 }
 
 #tasks-list {

--- a/src/main/webapp/index.jsp
+++ b/src/main/webapp/index.jsp
@@ -115,7 +115,7 @@
                   <img id="loading-gif" src="images/loading.gif" alt="Loading..."/>
               </div>
               <div id="location-missing-message" class="results-message">
-                  We could not retrieve your location to display your neighborhood tasks.
+                  We could not retrieve your location to display your neighborhood tasks. Please use the search box to manually enter a location.
               </div>
               <div id="tasks-message" class="results-message">
                   These are the most recent tasks in your neighborhood:

--- a/src/main/webapp/index.jsp
+++ b/src/main/webapp/index.jsp
@@ -107,7 +107,7 @@
               </div>
               <div id="search-box">
                 <label for="place-input">Search tasks in a different location:</label>
-                <input id="place-input" name="place-input" type="text" placeholder=" Type an address here" class="pac-target-input" autocomplete="off">
+                <input id="place-input" name="place-input" type="text" placeholder=" Type an address here" autocomplete="off">
               </div>
 
               <!--Results Messages-->

--- a/src/main/webapp/index.jsp
+++ b/src/main/webapp/index.jsp
@@ -105,6 +105,10 @@
                   }
                   %>
               </div>
+              <div id="search-box">
+                <label for="place-input">Search tasks in a different location:</label>
+                <input id="place-input" name="place-input" type="text" placeholder=" Type an address here" class="pac-target-input" autocomplete="off">
+              </div>
 
               <!--Results Messages-->
               <div id="loading" class="results-message">


### PR DESCRIPTION
An autocomplete search box was added to the top of the task results that allows users to enter a different address, select it and this will load tasks by the addresses's neighborhood instead. Additionally, if the search box doesn't have a valid input (a selection hasn't been made from the drop-down menu) it will default to the user's actual location.