### PR TITLE
implement map view option

### DIFF
--- a/src/main/java/com/google/neighborgood/User.java
+++ b/src/main/java/com/google/neighborgood/User.java
@@ -25,6 +25,8 @@ public final class User {
   private final String email;
   private final String userId;
   private final long points;
+  private final Double lat;
+  private final Double lng;
   private boolean isCurrentUser;
 
   public User(Entity entity) {
@@ -37,6 +39,8 @@ public final class User {
     this.email = (String) entity.getProperty("email");
     this.userId = entity.getKey().getName();
     this.points = (Long) entity.getProperty("points");
+    this.lat = (Double) entity.getProperty("lat");
+    this.lng = (Double) entity.getProperty("lng");
     this.isCurrentUser = false;
   }
 
@@ -46,5 +50,17 @@ public final class User {
 
   public String getUserId() {
     return this.userId;
+  }
+
+  public String getUserNickname() {
+    return this.nickname;
+  }
+
+  public Double getUserLat() {
+    return this.lat;
+  }
+
+  public Double getUserLng() {
+    return this.lng;
   }
 }

--- a/src/main/java/com/google/neighborgood/helper/TaskGroup.java
+++ b/src/main/java/com/google/neighborgood/helper/TaskGroup.java
@@ -25,20 +25,22 @@ import com.google.neighborgood.User;
 import com.google.neighborgood.task.Task;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 /**
  * Helper class that stores the HTML depiction of tasks in groups of 10 or less along with whether
  * or not the end of the query has been reached
  */
 public class TaskGroup {
-  private static HashMap<String, User>
+  private static Map<String, User>
       usersInfo; // Stores task owner's user info to prevent querying multiple times in
   // datastore for the same user's info
   private static DatastoreService datastore;
   private final boolean userLoggedIn;
   private int currentTaskCount;
   private boolean endOfQuery;
-  private ArrayList<Task> tasks;
+  private List<Task> tasks;
 
   public TaskGroup() {
     this.usersInfo = new HashMap<String, User>();
@@ -73,7 +75,7 @@ public class TaskGroup {
       } catch (EntityNotFoundException e) {
         System.err.println(
             "Unable to find the task's owner info to retrieve the owner's nickname. Setting a default nickname.");
-        taskOwnerNickname = "Neighbor";
+        taskOwnerNickname = "Your Friendly Neighbor";
       }
     }
     Task task = new Task(entity, taskOwnerId, taskOwnerNickname, taskLat, taskLng);

--- a/src/main/java/com/google/neighborgood/helper/TaskGroup.java
+++ b/src/main/java/com/google/neighborgood/helper/TaskGroup.java
@@ -66,6 +66,9 @@ public class TaskGroup {
       try {
         Entity userEntity = this.datastore.get(taskOwnerKey);
         User taskUser = new User(userEntity);
+        taskOwnerNickname = taskUser.getUserNickname();
+        taskLat = taskUser.getUserLat();
+        taskLng = taskUser.getUserLng();
         this.usersInfo.put(taskOwnerId, taskUser);
       } catch (EntityNotFoundException e) {
         System.err.println(

--- a/src/main/java/com/google/neighborgood/servlets/UserInfoServlet.java
+++ b/src/main/java/com/google/neighborgood/servlets/UserInfoServlet.java
@@ -95,8 +95,8 @@ public class UserInfoServlet extends HttpServlet {
     String phone = "";
     String zipcode = "";
     String country = "";
-    Float lat = null;
-    Float lng = null;
+    Double lat = null;
+    Double lng = null;
     String nicknameInput = request.getParameter("nickname-input");
     String addressInput = request.getParameter("address-input");
     String phoneInput = request.getParameter("phone-input");
@@ -112,8 +112,8 @@ public class UserInfoServlet extends HttpServlet {
     if (countryInput != null) country = countryInput.trim();
 
     try {
-      lat = Float.parseFloat(request.getParameter("lat-input"));
-      lng = Float.parseFloat(request.getParameter("lng-input"));
+      lat = Double.parseDouble(request.getParameter("lat"));
+      lng = Double.parseDouble(request.getParameter("lng"));
     } catch (NumberFormatException e) {
       System.err.println("Invalid location coordinates");
       response.sendError(HttpServletResponse.SC_BAD_REQUEST, "Invalid location coordinates");

--- a/src/main/java/com/google/neighborgood/servlets/UserInfoServlet.java
+++ b/src/main/java/com/google/neighborgood/servlets/UserInfoServlet.java
@@ -95,6 +95,8 @@ public class UserInfoServlet extends HttpServlet {
     String phone = "";
     String zipcode = "";
     String country = "";
+    Float lat = null;
+    Float lng = null;
     String nicknameInput = request.getParameter("nickname-input");
     String addressInput = request.getParameter("address-input");
     String phoneInput = request.getParameter("phone-input");
@@ -108,6 +110,14 @@ public class UserInfoServlet extends HttpServlet {
     if (phoneInput != null) phone = phoneInput.trim();
     if (zipcodeInput != null) zipcode = zipcodeInput.trim();
     if (countryInput != null) country = countryInput.trim();
+
+    try {
+      lat = Float.parseFloat(request.getParameter("lat-input"));
+      lng = Float.parseFloat(request.getParameter("lng-input"));
+    } catch (NumberFormatException e) {
+      System.err.println("Invalid location coordinates");
+      response.sendError(HttpServletResponse.SC_BAD_REQUEST, "Invalid location coordinates");
+    }
 
     if (nickname.equals("")
         || address.equals("")
@@ -135,6 +145,8 @@ public class UserInfoServlet extends HttpServlet {
       entity.setProperty("email", email);
       entity.setProperty("country", country);
       entity.setProperty("zipcode", zipcode);
+      entity.setProperty("lat", lat);
+      entity.setProperty("lng", lng);
       entity.setProperty("points", 0);
     } else {
       entity.setProperty("nickname", nickname);
@@ -142,6 +154,8 @@ public class UserInfoServlet extends HttpServlet {
       entity.setProperty("phone", phone);
       entity.setProperty("country", country);
       entity.setProperty("zipcode", zipcode);
+      entity.setProperty("lat", lat);
+      entity.setProperty("lng", lng);
     }
     datastore.put(entity);
     response.sendRedirect("/user_profile.jsp");

--- a/src/main/java/com/google/neighborgood/task/Task.java
+++ b/src/main/java/com/google/neighborgood/task/Task.java
@@ -90,6 +90,7 @@ public final class Task {
     setDateTime();
   }
 
+  // Constructor with provided ownerId, ownerNickn, ownerLat, and ownerLng
   public Task(
       Entity entity, String ownerId, String ownerNickname, Double ownerLat, Double ownerLng) {
     this.keyString = KeyFactory.keyToString(entity.getKey());

--- a/src/main/java/com/google/neighborgood/task/Task.java
+++ b/src/main/java/com/google/neighborgood/task/Task.java
@@ -39,6 +39,8 @@ public final class Task {
   private final String category;
   private boolean isOwnerCurrentUser;
   private String dateTime;
+  private Double lat;
+  private Double lng;
 
   public Task(Entity entity) {
     this.keyString = KeyFactory.keyToString(entity.getKey());
@@ -65,6 +67,9 @@ public final class Task {
       return;
     }
     this.owner = (String) ownerEntity.getProperty("nickname");
+    this.lat = (Double) ownerEntity.getProperty("lat");
+    this.lng = (Double) ownerEntity.getProperty("lng");
+
     // If the task status is still "OPEN", the input helper should be "N/A".
     // Otherwise, we will show the nickname of the helper.
     if (!helperId.equals("N/A")) {
@@ -85,7 +90,8 @@ public final class Task {
     setDateTime();
   }
 
-  public Task(Entity entity, String ownerId, String ownerNickname) {
+  public Task(
+      Entity entity, String ownerId, String ownerNickname, Double ownerLat, Double ownerLng) {
     this.keyString = KeyFactory.keyToString(entity.getKey());
     this.detail = (String) entity.getProperty("detail");
     this.overview = (String) entity.getProperty("overview");
@@ -97,6 +103,8 @@ public final class Task {
     this.country = (String) entity.getProperty("country");
     this.category = (String) entity.getProperty("category");
     this.owner = ownerNickname;
+    this.lat = ownerLat;
+    this.lng = ownerLng;
 
     DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
     String helperId = (String) entity.getProperty("Helper");

--- a/src/main/java/com/google/neighborgood/task/Task.java
+++ b/src/main/java/com/google/neighborgood/task/Task.java
@@ -81,7 +81,7 @@ public final class Task {
       this.helper = "N/A";
     }
 
-    setOwnerCurrentUser(ownerId);
+    setIsOwnerCurrentUser(ownerId);
     setDateTime();
   }
 
@@ -117,7 +117,7 @@ public final class Task {
       this.helper = "N/A";
     }
 
-    setOwnerCurrentUser(ownerId);
+    setIsOwnerCurrentUser(ownerId);
     setDateTime();
   }
 
@@ -127,7 +127,7 @@ public final class Task {
     this.dateTime = timestampFormat.format(timestamp);
   }
 
-  private void setOwnerCurrentUser(String ownerId) {
+  private void setIsOwnerCurrentUser(String ownerId) {
     UserService userService = UserServiceFactory.getUserService();
     boolean userLoggedIn = userService.isUserLoggedIn();
     String userId = userLoggedIn ? userService.getCurrentUser().getUserId() : "null";

--- a/src/main/webapp/account.jsp
+++ b/src/main/webapp/account.jsp
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <title>My Personal Info</title>
     <link rel="stylesheet" href="account_style.css">
+    <script type='text/javascript' src='map_styles.js'></script>
     <script type='text/javascript' src='config.js'></script>
     <script src="user_profile_script.js"></script>
   </head>

--- a/src/main/webapp/account.jsp
+++ b/src/main/webapp/account.jsp
@@ -36,7 +36,7 @@
                 </div>
                 <br/>
                 <textarea name="address-input" id="edit-address-input" placeholder="Input your address here:"></textarea>
-                <p id="rest-map">Click to mark your personal address on the map!</p>
+                <p id="rest-map">Click to mark your personal address on the map!<span class="req">*</span></p>
                 <input id="place-input" class="controls" type="text" placeholder="Search Box">
                 <div id="map"></div>
                 <br/><br/>
@@ -60,6 +60,8 @@
                 </div>
                 <br/>
                 <input type="text" name="phone-input" id="phone-input" placeholder="Input your phone number here:">
+                <input type="hidden" name="lat-input" id="lat-input">
+                <input type="hidden" name="lng-input" id="lng-input">
                 <br/><br/>
                 <button type="submit" id="submit-button"/>GET STARTED</button>
                 <br/><br/>

--- a/src/main/webapp/account.jsp
+++ b/src/main/webapp/account.jsp
@@ -60,8 +60,8 @@
                 </div>
                 <br/>
                 <input type="text" name="phone-input" id="phone-input" placeholder="Input your phone number here:">
-                <input type="hidden" name="lat-input" id="lat-input">
-                <input type="hidden" name="lng-input" id="lng-input">
+                <input type="hidden" name="lat" id="lat-input">
+                <input type="hidden" name="lng" id="lng-input">
                 <br/><br/>
                 <button type="submit" id="submit-button"/>GET STARTED</button>
                 <br/><br/>

--- a/src/main/webapp/account_style.css
+++ b/src/main/webapp/account_style.css
@@ -94,7 +94,6 @@ label {
 }
 
 #map {
-  border: thin solid black;
   height: 400px;
   max-width: 100%;
   color: black;

--- a/src/main/webapp/homepage_script.js
+++ b/src/main/webapp/homepage_script.js
@@ -234,19 +234,25 @@ function closeCreateTaskModal() {
 function validateTaskForm(id) {
     var result = true;
     var form = document.getElementById(id);
-    var inputName = ["task-overview", "task-detail", "reward", "category"];
+    var inputName = ["task-overview", "task-detail", "reward", "category", "lat", "lng"];
     for (var i = 0; i < inputName.length; i++) {
         var name = inputName[i];
         var inputField = form[name.concat("-input")].value.trim();
         if (inputField === "") {
             result = false;
             form[name.concat("-input")].classList.add("highlight");
+            if (inputName[i] === "lat" || inputName[i] === "lng") {
+                document.getElementById("map").classList.add("highlight");
+            }
         } else {
             form[name.concat("-input")].classList.remove("highlight");
+            if (inputName[i] === "lat" || inputName[i] === "lng") {
+                document.getElementById("map").classList.remove("highlight");
+            }
         }
     }
     if (!result) {
-        alert("All fields are required. Please fill out all fields with non-empty input.");
+        alert("All fields are required. Please fill out all fields with non-empty input and mark your personal address on the map.");
         return false;
     }
     return true;

--- a/src/main/webapp/homepage_script.js
+++ b/src/main/webapp/homepage_script.js
@@ -164,7 +164,7 @@ function switchView(element) {
 /* Helper function that switches to map view */
 function switchToMap() {
     document.getElementById("tasks-list").style.display = "none";
-    document.getElementById("tasks-map").style.display = "block";
+    document.getElementById("tasks-map-wrapper").style.display = "block";
     currentView = "map";
     map.setCenter(userLocation);
     taskGroup.tasks.forEach(task => displayTaskMarker(task));
@@ -172,7 +172,7 @@ function switchToMap() {
 
 /* Helper function that switches to list view */
 function switchToList() {
-    document.getElementById("tasks-map").style.display = "none";
+    document.getElementById("tasks-map-wrapper").style.display = "none";
     document.getElementById("tasks-list").style.display = "block";
     currentView = "list";
 }
@@ -700,7 +700,7 @@ function fetchTasks(category, cursorAction) {
 
 /* Displays the tasks received from the server response */
 function displayTasks(append) {
-    let taskMap = document.getElementById("tasks-map");
+    let taskMap = document.getElementById("tasks-map-wrapper");
     let taskList = document.getElementById("tasks-list");
 
     if (taskGroup !== null && taskGroup.currentTaskCount > 0) {
@@ -846,9 +846,17 @@ function openInfoWindow(map, marker, infoWindow) {
         helpOutButton.innerText = "Help Out";
         helpOutButton.className = "help-out-marker";
         helpOutButton.addEventListener("click", function(e) {
-            if (confirm("Are you sure you want to help out with this task?")) {
+            let helpOverlay = document.getElementById("help-overlay-map");
+            helpOverlay.style.display = "block";
+            document.getElementById("confirm-map").addEventListener("click", function(e) {
                 confirmHelp(marker.get("key"));
-            }
+                helpOverlay.style.display = "none";
+                e.stopPropagation();
+            });
+            document.getElementById("exit-help-map").addEventListener("click", function(e) {
+                helpOverlay.style.display = "none";
+                e.stopPropagation();
+            });
             e.stopPropagation();
         });
         windowNode.appendChild(helpOutButton);
@@ -869,12 +877,13 @@ function addTasksClickHandlers() {
     // adds confirmHelp click event listener to confirm help buttons
     const confirmHelpButtons = document.getElementsByClassName("confirm-help");
     for (let i = 0; i < confirmHelpButtons.length; i++){
-        confirmHelpButtons[i].addEventListener("click", function(e) {
-            let taskKey = e.target.closest(".task").dataset.key;
-            confirmHelp(taskKey);
-            e.stopPropagation();
-        });
-        
+        if (confirmHelpButtons[i].id != "confirm-map") {
+            confirmHelpButtons[i].addEventListener("click", function(e) {
+                let taskKey = e.target.closest(".task").dataset.key;
+                confirmHelp(taskKey);
+                e.stopPropagation();
+            });
+        } 
     }
     // adds exitHelp click event listener to exit help buttons
     const exitHelpButtons = document.getElementsByClassName("exit-help");

--- a/src/main/webapp/homepage_script.js
+++ b/src/main/webapp/homepage_script.js
@@ -16,6 +16,7 @@ const MAPSKEY = config.MAPS_KEY;
 const GOOGLE_KIRKLAND_LAT = 47.669846;
 const GOOGLE_KIRKLAND_LNG = -122.1996099;
 let map;
+let oms;
 let neighborhood = [null , null];
 let userLocation = null;
 let userActualLocation = null;
@@ -502,6 +503,12 @@ function getTasksForUserLocation() {
         });
         map.setTilt(45);
 
+        oms = new OverlappingMarkerSpiderfier(map, {
+            markersWontMove: true,
+            markersWontHide: true,
+            basicFormatEvents: true
+        });
+
         // gets user location, then calls helper function that calls toNeighborhood, fetchTasks, and displayTasks
         getUserLocation().then(callEndOfInitFunctions);
 
@@ -706,8 +713,10 @@ function createTaskListNode(task) {
 }
 
 function displayTaskMarker(task) {
+    let lat = task.lat;// + (Math.random() - 0.5) / 3000;
+    let lng = task.lng;// + (Math.random() - 0.5) / 3000;
     const marker = new google.maps.Marker({
-        position: {lat: task.lat, lng: task.lng},
+        position: {lat: lat, lng: lng},
         map: map,
         isCurrentUser: task.isOwnerCurrentUser,
         detail: task.detail,
@@ -724,9 +733,10 @@ function displayTaskMarker(task) {
     });
 
     const geocoder = new google.maps.Geocoder;
-    marker.addListener("click", () => {
+    marker.addListener("spider_click", () => {
         openInfoWindow(map, marker, infoWindow);
     });
+    oms.addMarker(marker);
 }
 
 /** Builds and Opens Info Window */

--- a/src/main/webapp/homepage_script.js
+++ b/src/main/webapp/homepage_script.js
@@ -549,9 +549,9 @@ function getTasksForUserLocation() {
             toNeighborhood(map.getCenter().toJSON()).then(() => {
                 if (previousNeighborhood[0] != neighborhood[0] || previousNeighborhood[1] != neighborhood[1]) {
                     let searchNeighborhoodNode = document.createElement("div");
-                    let searchNeighborhood = new SearchAreaControl(searchNeighborhoodNode);
                     searchNeighborhoodNode.index = 1;
                     map.controls[google.maps.ControlPosition.TOP_CENTER].push(searchNeighborhoodNode);
+                    new SearchNeighborhoodMapControl(searchNeighborhoodNode);
                 } 
             });
         });
@@ -601,12 +601,12 @@ function callEndOfInitFunctions() {
         });
 }
 
-/** Constructs Search Area Map Control */
-function SearchAreaControl(controlNode) {
+/** Constructs Search Neighborhood Map Control */
+function SearchNeighborhoodMapControl(controlNode) {
     const controlUI = document.createElement("div");
     controlUI.setAttribute("id", "search-area-control");
     controlUI.title = "Click to search current neighborhood";
-    controlUI.textContent = "Search current area";
+    controlUI.textContent = "Search current neighborhood";
     controlNode.appendChild(controlUI);
     controlUI.addEventListener("click", function() {
         fetchTasks(currentCategory, "clear")
@@ -703,12 +703,12 @@ function displayTasks(append) {
     let taskMap = document.getElementById("tasks-map");
     let taskList = document.getElementById("tasks-list");
 
-    console.log(taskGroup);
-
     if (taskGroup !== null && taskGroup.currentTaskCount > 0) {
         document.getElementById("no-tasks-message").style.display = "none";
 
-        if (!append) taskList.innerHTML = "";
+        if (!append) {
+            taskList.innerHTML = "";
+        }
         taskGroup.tasks.map(createTaskListNode).forEach(node => taskList.appendChild(node));
         addTasksClickHandlers();
 
@@ -720,6 +720,7 @@ function displayTasks(append) {
             taskList.style.display = "none";
         }
     } else {
+        taskList.innerHTML = "";
         document.getElementById("no-tasks-message").style.display = "block";
         taskList.style.display = "none";
     }

--- a/src/main/webapp/homepage_script.js
+++ b/src/main/webapp/homepage_script.js
@@ -593,9 +593,10 @@ function callEndOfInitFunctions() {
         .then(response => {
                 taskGroup = response;
                 displayTasks();
+                map.setCenter(userLocation);
+                taskGroup.tasks.forEach(task => displayTaskMarker(task));
             })
         .catch(() => {
-            console.error("User location and/or neighborhood could not be retrieved");
             document.getElementById("loading").style.display = "none";
             document.getElementById("location-missing-message").style.display = "block";
         });

--- a/src/main/webapp/homepage_script.js
+++ b/src/main/webapp/homepage_script.js
@@ -335,6 +335,9 @@ function getTasksForUserLocation() {
                 toNeighborhood(userLocation)
                     .then(() => fetchTasks())
                     .then(response => {
+                            taskGroup = response;
+                            startCursor = taskGroup.startCursor;
+                            endCursor = taskGroup.endCursor;
                             displayTasks(response);
                         })
                     .catch(() => {
@@ -440,9 +443,11 @@ function displayTasks(append) {
     if (taskGroup !== null && taskGroup.currentTaskCount > 0) {
         document.getElementById("no-tasks-message").style.display = "none";
         document.getElementById("tasks-message").style.display = "block";
-        if (append) document.getElementById("tasks-list").innerHTML += taskGroup.tasks;
-        else document.getElementById("tasks-list").innerHTML = taskGroup.tasks;
         document.getElementById("tasks-list").style.display = "block";
+
+        let taskList = document.getElementById("tasks-list");
+        if (append != true) taskList.innerHTML = "";
+        taskGroup.tasks.map(createTaskNode).forEach(node => taskList.appendChild(node));
         addTasksClickHandlers();
     } else {
         document.getElementById("no-tasks-message").style.display = "block";
@@ -451,6 +456,68 @@ function displayTasks(append) {
     }
     document.getElementById("loading").style.display = "none";
     document.getElementById("search-box").style.visibility = "visible";
+}
+
+function createTaskNode(task) {
+    let taskDiv = document.createElement("div");
+    taskDiv.className = "task";
+    taskDiv.setAttribute("data-key", task.keyString);
+
+    if (taskGroup.userLoggedIn == true && task.isOwnerCurrentUser == false) {
+        let helpOverlay = document.createElement("div");
+        helpOverlay.className = "help-overlay";
+        let exitHelp = document.createElement("div");
+        exitHelp.className = "exit-help";
+        let exitLink = document.createElement("a");
+        exitLink.innerText = "×";
+        let confirmHelp = document.createElement("a");
+        confirmHelp.className = "confirm-help";
+        confirmHelp.innerText = "CONFIRM";
+
+        exitHelp.appendChild(exitLink);
+        helpOverlay.appendChild(exitHelp);
+        helpOverlay.appendChild(confirmHelp);
+        taskDiv.appendChild(helpOverlay);
+    }
+
+    let taskContainer = document.createElement("div");
+    taskContainer.className = "task-container";
+    let taskHeader = document.createElement("div");
+    taskHeader.className = "task-header";
+    let userNickname = document.createElement("div");
+    userNickname.className = "user-nickname";
+    userNickname.innerText = task.owner;
+    taskHeader.appendChild(userNickname);
+
+    if (taskGroup.userLoggedIn == true && task.isOwnerCurrentUser == false) {
+        let helpOut = document.createElement("div");
+        helpOut.className = "help-out";
+        helpOut.innerText = "HELP OUT";
+        taskHeader.appendChild(helpOut);
+    }
+
+    let taskContent = document.createElement("div");
+    taskContent.className = "task-content";
+    taskContent.innerText = task.overview;
+
+    let taskFooter = document.createElement("div");
+    taskFooter.className = "task-footer";
+    let taskCategory = document.createElement("div");
+    taskCategory.className = "task-category";
+    taskCategory.innerText = "#" + task.category;
+    let taskDateTime = document.createElement("div");
+    taskDateTime.className = "task-date-time";
+    taskDateTime.innerText = task.dateTime;
+    taskFooter.appendChild(taskCategory);
+    taskFooter.appendChild(taskDateTime);
+
+    taskContainer.appendChild(taskHeader);
+    taskContainer.appendChild(taskContent);
+    taskContainer.appendChild(taskFooter);
+
+    taskDiv.appendChild(taskContainer);
+
+    return taskDiv;
 }
 
 /* Function adds all the necessary tasks 'click' event listeners*/

--- a/src/main/webapp/homepage_script.js
+++ b/src/main/webapp/homepage_script.js
@@ -846,7 +846,9 @@ function openInfoWindow(map, marker, infoWindow) {
         helpOutButton.innerText = "Help Out";
         helpOutButton.className = "help-out-marker";
         helpOutButton.addEventListener("click", function(e) {
-            confirmHelp(marker.get("key"));
+            if (confirm("Are you sure you want to help out with this task?")) {
+                confirmHelp(marker.get("key"));
+            }
             e.stopPropagation();
         });
         windowNode.appendChild(helpOutButton);

--- a/src/main/webapp/homepage_script.js
+++ b/src/main/webapp/homepage_script.js
@@ -988,7 +988,13 @@ function addTasksClickHandlers() {
     const tasks = document.getElementsByClassName("task");
     for (let i = 0; i < tasks.length; i++) {
         tasks[i].addEventListener("click", function(e) {
-            showTaskInfo(e.target.dataset.key);
+            let taskElement = e.target;
+
+            // If element clicked was a child element it closest task ancestor instead
+            if (taskElement.className != "task") {
+                taskElement = taskElement.closest(".task");
+            }
+            showTaskInfo(taskElement.dataset.key);
         });
     }
 }

--- a/src/main/webapp/homepage_script.js
+++ b/src/main/webapp/homepage_script.js
@@ -327,9 +327,14 @@ function getTasksForUserLocation() {
     document.head.appendChild(script);
 
     // Once the Maps API script has dynamically loaded it gets the user location,
-    // waits until it gets an answer updates the global userLoaction variable and then calls
+    // waits until it gets an answer updates the global userLocation variable and then calls
     // fetchTasks and displayTasks
+    // It also initializes the autocomplete search box and the map.
 	window.initialize = function () {
+        // gets user location, then calls helper function that calls toNeighborhood, fetchTasks, and displayTasks
+        getUserLocation().then(callEndOfInitFunctions);
+
+        // initialize autocomplete input text search box
         let placeAutocomplete = new google.maps.places.Autocomplete(document.getElementById("place-input"));
         placeAutocomplete.setFields(['geometry']);
         google.maps.event.addListener(placeAutocomplete, 'place_changed', function() {
@@ -341,6 +346,8 @@ function getTasksForUserLocation() {
                 }
                 callEndOfInitFunctions();
               });
+
+        // initialize map
         map = new google.maps.Map(document.getElementById("tasks-map"), {
             center: {lat: GOOGLE_KIRKLAND_LAT, lng: GOOGLE_KIRKLAND_LNG},
             zoom: 15,
@@ -480,8 +487,6 @@ function getTasksForUserLocation() {
             ],
         });
         map.setTilt(45);
-        getUserLocation().then(callEndOfInitFunctions);
-        
 	}
 }
 
@@ -585,7 +590,6 @@ function fetchTasks(category, cursor) {
 function displayTasks(append) {
     if (taskGroup !== null && taskGroup.currentTaskCount > 0) {
         document.getElementById("no-tasks-message").style.display = "none";
-        document.getElementById("tasks-message").style.display = "block";
         document.getElementById("tasks-list").style.display = "block";
 
         let taskList = document.getElementById("tasks-list");
@@ -594,11 +598,9 @@ function displayTasks(append) {
         addTasksClickHandlers();
     } else {
         document.getElementById("no-tasks-message").style.display = "block";
-        document.getElementById("tasks-message").style.display = "none";
         document.getElementById("tasks-list").style.display = "none";
     }
     document.getElementById("loading").style.display = "none";
-    document.getElementById("search-box").style.visibility = "visible";
 }
 
 function createTaskNode(task) {

--- a/src/main/webapp/homepage_script.js
+++ b/src/main/webapp/homepage_script.js
@@ -628,6 +628,11 @@ function SearchNeighborhoodMapControl(controlNode) {
             .then(response => {
                     taskGroup = response;
                     displayTasks();
+                    markersMap.forEach((marker) => {
+                        oms.forgetMarker(marker);
+                        marker.setMap(null);
+                    });
+                    markersMap.clear();
                     taskGroup.tasks.forEach(task => displayTaskMarker(task));
                     controlNode.remove();
                 })

--- a/src/main/webapp/homepage_script.js
+++ b/src/main/webapp/homepage_script.js
@@ -373,9 +373,8 @@ async function getTaskInfo(keyString) {
     return info;
 }
 
-async function showTaskInfo(element) {
-    const task = element.closest(".task");
-    const info = await getTaskInfo(task.dataset.key);
+async function showTaskInfo(taskKey) {
+    const info = await getTaskInfo(taskKey);
     var detailContainer = document.getElementById("task-detail-container");
     detailContainer.innerHTML = "";
     detailContainer.appendChild(document.createTextNode(info.detail));
@@ -791,7 +790,6 @@ function createTaskListNode(task) {
 }
 
 function displayTaskMarker(task) {
-    console.log(task);
     // only adds task that aren't already loaded in map
     if (!markersMap.has(task.keyString)) {
         const marker = new google.maps.Marker({
@@ -847,9 +845,16 @@ function openInfoWindow(map, marker, infoWindow) {
         const helpOutButton = document.createElement("button");
         helpOutButton.innerText = "Help Out";
         helpOutButton.className = "help-out-marker";
-        helpOutButton.onclick = () => {confirmHelp(marker.get("key"));}
+        helpOutButton.addEventListener("click", function(e) {
+            confirmHelp(marker.get("key"));
+            e.stopPropagation();
+        });
         windowNode.appendChild(helpOutButton);
     }
+
+    windowNode.addEventListener("click", function() {
+        showTaskInfo(marker.get("key"));
+    });
     
     infoWindow.setContent(windowNode);
     infoWindow.open(map, marker);
@@ -901,7 +906,7 @@ function addTasksClickHandlers() {
     const tasks = document.getElementsByClassName("task");
     for (let i = 0; i < tasks.length; i++) {
         tasks[i].addEventListener("click", function(e) {
-            showTaskInfo(e.target);
+            showTaskInfo(e.target.dataset.key);
         });
     }
 }

--- a/src/main/webapp/homepage_script.js
+++ b/src/main/webapp/homepage_script.js
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 const MAPSKEY = config.MAPS_KEY;
+const MAP_STYLE = styles;
 const GOOGLE_KIRKLAND_LAT = 47.669846;
 const GOOGLE_KIRKLAND_LNG = -122.1996099;
 let map;
@@ -434,140 +435,7 @@ function getTasksForUserLocation() {
             fullscreenControl: false,
             center: {lat: GOOGLE_KIRKLAND_LAT, lng: GOOGLE_KIRKLAND_LNG},
             zoom: 12,
-            styles: [
-                {
-                    "elementType": "geometry",
-                    "stylers": [{"color": "#ebe3cd"}]
-                },
-                {
-                    "elementType": "labels.text.fill",
-                    "stylers": [{"color": "#523735"}]
-                },
-                {
-                    "elementType": "labels.text.stroke",
-                    "stylers": [{"color": "#f5f1e6"}]
-                },
-                {
-                    "featureType": "administrative",
-                    "elementType": "geometry.stroke",
-                    "stylers": [{"color": "#c9b2a6"}]
-                },
-                {
-                    "featureType": "administrative.land_parcel",
-                    "elementType": "geometry.stroke",
-                    "stylers": [{"color": "#dcd2be"}]
-                },
-                {
-                    "featureType": "administrative.land_parcel",
-                    "elementType": "labels.text.fill",
-                    "stylers": [{"color": "#ae9e90"}]
-                },
-                {
-                    "featureType": "landscape.man_made",
-                    "elementType": "geometry.stroke",
-                    "stylers": [{"color": "#36aff9"}]
-                },
-                {
-                    "featureType": "landscape.natural",
-                    "elementType": "geometry",
-                    "stylers": [{"color": "#dfd2ae"}]
-                },
-                {
-                    "featureType": "poi",
-                    "elementType": "geometry",
-                    "stylers": [{"color": "#dfd2ae"}]
-                },
-                {
-                    "featureType": "poi",
-                    "elementType": "labels.text.fill",
-                    "stylers": [{"color": "#93817c"}]
-                },
-                {
-                    "featureType": "poi.park",
-                    "elementType": "geometry.fill",
-                    "stylers": [{"color": "#a5b076"}]
-                },
-                {
-                    "featureType": "poi.park",
-                    "elementType": "labels.text.fill",
-                    "stylers": [{"color": "#28c4fa"}, {"lightness": -5}, {"weight": 2}]
-                },
-                {
-                    "featureType": "poi.park",
-                    "elementType": "labels.text.stroke",
-                    "stylers": [{"color": "#f9fcc7"}]
-                },
-                {
-                    "featureType": "road",
-                    "elementType": "geometry",
-                    "stylers": [{"color": "#f5f1e6"}]
-                },
-                {
-                    "featureType": "road.arterial",
-                    "elementType": "geometry",
-                    "stylers": [{"color": "#fdfcf8"}]
-                },
-                {
-                    "featureType": "road.highway",
-                    "elementType": "geometry",
-                    "stylers": [{"color": "#f8c967"}]
-                },
-                {
-                    "featureType": "road.highway",
-                    "elementType": "geometry.stroke",
-                    "stylers": [{"color": "#f2756a"}]
-                },
-                {
-                    "featureType": "road.highway",
-                    "elementType": "labels.text.fill",
-                    "stylers": [{"color": "#f98357"}]
-                },
-                {
-                    "featureType": "road.highway.controlled_access",
-                    "elementType": "geometry",
-                    "stylers": [{"color": "#e98d58"}]
-                },
-                {
-                    "featureType": "road.highway.controlled_access",
-                    "elementType": "geometry.stroke",
-                    "stylers": [{"color": "#db8555"}]
-                },
-                {
-                    "featureType": "road.local",
-                    "elementType": "labels.text.fill",
-                    "stylers": [{"color": "#806b63"}]
-                },
-                {
-                    "featureType": "transit.line",
-                    "elementType": "geometry",
-                    "stylers": [{"color": "#dfd2ae"}]
-                },
-                {
-                    "featureType": "transit.line",
-                    "elementType": "labels.text.fill",
-                    "stylers": [{"color": "#8f7d77"}]
-                },
-                {
-                    "featureType": "transit.line",
-                    "elementType": "labels.text.stroke",
-                    "stylers": [{"color": "#ebe3cd"}]
-                },
-                {
-                    "featureType": "transit.station",
-                    "elementType": "geometry",
-                    "stylers": [{"color": "#dfd2ae"}]
-                },
-                {
-                    "featureType": "water",
-                    "elementType": "geometry.fill",
-                    "stylers": [{"color": "#65d3f9"}, {"saturation": -10},  {"lightness": 10}]
-                },
-                {
-                    "featureType": "water",
-                    "elementType": "labels.text.fill",
-                    "stylers": [{"color": "#92998d"}]
-                }
-            ],
+            styles: MAP_STYLE,
         });
         map.setTilt(45);
 

--- a/src/main/webapp/homepage_script.js
+++ b/src/main/webapp/homepage_script.js
@@ -15,10 +15,12 @@
 const MAPSKEY = config.MAPS_KEY;
 const GOOGLE_KIRKLAND_LAT = 47.669846;
 const GOOGLE_KIRKLAND_LNG = -122.1996099;
+let map;
 let neighborhood = [null , null];
 let userLocation = null;
 let userActualLocation = null;
 let currentCategory = "all";
+let currentView = "list";
 let taskGroup = null;
 
 /* Changes navbar background upon resize */
@@ -119,9 +121,13 @@ function switchView(element) {
     if (buttonElement.value == "map") {
         document.getElementById("tasks-list").style.display = "none";
         document.getElementById("tasks-map").style.display = "block";
+        currentView = "map";
+        map.setCenter(userLocation);
+
     } else {
         document.getElementById("tasks-map").style.display = "none";
         document.getElementById("tasks-list").style.display = "block";
+        currentView = "list";
     }
 }
 
@@ -364,7 +370,7 @@ function getTasksForUserLocation() {
         // initialize map
         map = new google.maps.Map(document.getElementById("tasks-map"), {
             center: {lat: GOOGLE_KIRKLAND_LAT, lng: GOOGLE_KIRKLAND_LNG},
-            zoom: 15,
+            zoom: 13,
             styles: [
                 {
                     "elementType": "geometry",
@@ -599,17 +605,27 @@ function fetchTasks(category, cursorAction) {
 
 /* Displays the tasks received from the server response */
 function displayTasks(append) {
+    let taskMap = document.getElementById("tasks-map");
+    let taskList = document.getElementById("tasks-list");
+
     if (taskGroup !== null && taskGroup.currentTaskCount > 0) {
         document.getElementById("no-tasks-message").style.display = "none";
-        document.getElementById("tasks-list").style.display = "block";
 
-        let taskList = document.getElementById("tasks-list");
         if (append != true) taskList.innerHTML = "";
         taskGroup.tasks.map(createTaskNode).forEach(node => taskList.appendChild(node));
         addTasksClickHandlers();
+
+        if (currentView === "list") {
+            taskList.style.display = "block";
+            taskMap.style.display = "none";
+        } else if (currentView === "map") {
+            taskMap.style.display = "block";
+            taskList.style.display = "none";
+        }
     } else {
         document.getElementById("no-tasks-message").style.display = "block";
-        document.getElementById("tasks-list").style.display = "none";
+        taskList.style.display = "none";
+        taskMap.style.display = "none";
     }
     document.getElementById("loading").style.display = "none";
 }

--- a/src/main/webapp/homepage_script.js
+++ b/src/main/webapp/homepage_script.js
@@ -753,8 +753,6 @@ function displayTasks(append) {
     }
 
     if (taskGroup !== null && taskGroup.currentTaskCount > 0) {
-
-        if (!append) taskList.innerHTML = "";
         
         document.getElementById("no-tasks-message").style.display = "none";
 
@@ -778,9 +776,11 @@ function displayTasks(append) {
             else loadMoreTasksMapControl.style.display = "block";
         }
     } else {
-        taskList.innerHTML = "";
-        document.getElementById("no-tasks-message").style.display = "block";
-        taskList.style.display = "none";
+        if (!append) {
+            taskList.innerHTML = "";
+            document.getElementById("no-tasks-message").style.display = "block";
+            taskList.style.display = "none";
+        }
     }
     document.getElementById("loading").style.display = "none";
 }

--- a/src/main/webapp/homepage_script.js
+++ b/src/main/webapp/homepage_script.js
@@ -12,7 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-const MAPSKEY = config.MAPS_KEY
+const MAPSKEY = config.MAPS_KEY;
+const GOOGLE_KIRKLAND_LAT = 47.669846;
+const GOOGLE_KIRKLAND_LNG = -122.1996099;
 let neighborhood = [null , null];
 let userLocation = null;
 let userActualLocation = null;
@@ -337,33 +339,166 @@ function getTasksForUserLocation() {
                 } else {
                     userLocation = userActualLocation;
                 }
-                toNeighborhood(userLocation)
-                        .then(() => fetchTasks())
-                        .then(response => {
-                                taskGroup = response;
-                                startCursor = taskGroup.startCursor;
-                                endCursor = taskGroup.endCursor;
-                                displayTasks(response);
-                            })
-                        .catch(() => {
-                            console.error("User location and/or neighborhood could not be retrieved");
-                            document.getElementById("location-missing-message").style.display = "block";
-                        });
+                callEndOfInitFunctions();
               });
-         getUserLocation().then(location => toNeighborhood(location))
-        	.then(() => fetchTasks(currentCategory))
-            .then(response => {
-                    taskGroup = response;
-                    startCursor = taskGroup.startCursor;
-                    endCursor = taskGroup.endCursor;
-                    displayTasks();
-                })
-            .catch(() => {
-                console.error("User location and/or neighborhood could not be retrieved");
-                document.getElementById("loading").style.display = "none";
-                document.getElementById("location-missing-message").style.display = "block";
-            });
+        map = new google.maps.Map(document.getElementById("tasks-map"), {
+            center: {lat: GOOGLE_KIRKLAND_LAT, lng: GOOGLE_KIRKLAND_LNG},
+            zoom: 15,
+            styles: [
+                {
+                    "elementType": "geometry",
+                    "stylers": [{"color": "#ebe3cd"}]
+                },
+                {
+                    "elementType": "labels.text.fill",
+                    "stylers": [{"color": "#523735"}]
+                },
+                {
+                    "elementType": "labels.text.stroke",
+                    "stylers": [{"color": "#f5f1e6"}]
+                },
+                {
+                    "featureType": "administrative",
+                    "elementType": "geometry.stroke",
+                    "stylers": [{"color": "#c9b2a6"}]
+                },
+                {
+                    "featureType": "administrative.land_parcel",
+                    "elementType": "geometry.stroke",
+                    "stylers": [{"color": "#dcd2be"}]
+                },
+                {
+                    "featureType": "administrative.land_parcel",
+                    "elementType": "labels.text.fill",
+                    "stylers": [{"color": "#ae9e90"}]
+                },
+                {
+                    "featureType": "landscape.man_made",
+                    "elementType": "geometry.stroke",
+                    "stylers": [{"color": "#36aff9"}]
+                },
+                {
+                    "featureType": "landscape.natural",
+                    "elementType": "geometry",
+                    "stylers": [{"color": "#dfd2ae"}]
+                },
+                {
+                    "featureType": "poi",
+                    "elementType": "geometry",
+                    "stylers": [{"color": "#dfd2ae"}]
+                },
+                {
+                    "featureType": "poi",
+                    "elementType": "labels.text.fill",
+                    "stylers": [{"color": "#93817c"}]
+                },
+                {
+                    "featureType": "poi.park",
+                    "elementType": "geometry.fill",
+                    "stylers": [{"color": "#a5b076"}]
+                },
+                {
+                    "featureType": "poi.park",
+                    "elementType": "labels.text.fill",
+                    "stylers": [{"color": "#28c4fa"}, {"lightness": -5}, {"weight": 2}]
+                },
+                {
+                    "featureType": "poi.park",
+                    "elementType": "labels.text.stroke",
+                    "stylers": [{"color": "#f9fcc7"}]
+                },
+                {
+                    "featureType": "road",
+                    "elementType": "geometry",
+                    "stylers": [{"color": "#f5f1e6"}]
+                },
+                {
+                    "featureType": "road.arterial",
+                    "elementType": "geometry",
+                    "stylers": [{"color": "#fdfcf8"}]
+                },
+                {
+                    "featureType": "road.highway",
+                    "elementType": "geometry",
+                    "stylers": [{"color": "#f8c967"}]
+                },
+                {
+                    "featureType": "road.highway",
+                    "elementType": "geometry.stroke",
+                    "stylers": [{"color": "#f2756a"}]
+                },
+                {
+                    "featureType": "road.highway",
+                    "elementType": "labels.text.fill",
+                    "stylers": [{"color": "#f98357"}]
+                },
+                {
+                    "featureType": "road.highway.controlled_access",
+                    "elementType": "geometry",
+                    "stylers": [{"color": "#e98d58"}]
+                },
+                {
+                    "featureType": "road.highway.controlled_access",
+                    "elementType": "geometry.stroke",
+                    "stylers": [{"color": "#db8555"}]
+                },
+                {
+                    "featureType": "road.local",
+                    "elementType": "labels.text.fill",
+                    "stylers": [{"color": "#806b63"}]
+                },
+                {
+                    "featureType": "transit.line",
+                    "elementType": "geometry",
+                    "stylers": [{"color": "#dfd2ae"}]
+                },
+                {
+                    "featureType": "transit.line",
+                    "elementType": "labels.text.fill",
+                    "stylers": [{"color": "#8f7d77"}]
+                },
+                {
+                    "featureType": "transit.line",
+                    "elementType": "labels.text.stroke",
+                    "stylers": [{"color": "#ebe3cd"}]
+                },
+                {
+                    "featureType": "transit.station",
+                    "elementType": "geometry",
+                    "stylers": [{"color": "#dfd2ae"}]
+                },
+                {
+                    "featureType": "water",
+                    "elementType": "geometry.fill",
+                    "stylers": [{"color": "#65d3f9"}, {"saturation": -10},  {"lightness": 10}]
+                },
+                {
+                    "featureType": "water",
+                    "elementType": "labels.text.fill",
+                    "stylers": [{"color": "#92998d"}]
+                }
+            ],
+        });
+        map.setTilt(45);
+        getUserLocation().then(callEndOfInitFunctions);
+        
 	}
+}
+
+function callEndOfInitFunctions() {
+    toNeighborhood(userLocation)
+        .then(() => fetchTasks(currentCategory))
+        .then(response => {
+                taskGroup = response;
+                startCursor = taskGroup.startCursor;
+                endCursor = taskGroup.endCursor;
+                displayTasks();
+            })
+        .catch(() => {
+            console.error("User location and/or neighborhood could not be retrieved");
+            document.getElementById("loading").style.display = "none";
+            document.getElementById("location-missing-message").style.display = "block";
+        });
 }
 
 /* Function that returns a promise to get and return the user's location */

--- a/src/main/webapp/homepage_script.js
+++ b/src/main/webapp/homepage_script.js
@@ -47,7 +47,7 @@ window.onscroll = function() {
 
 /* Adds scroll event listener to load more tasks if the user has reached the bottom of the page */
 document.addEventListener("scroll", function() {
-    if (getDocumentHeight() == getVerticalScroll() + window.innerHeight) {
+    if (getDocumentHeight() == getVerticalScroll() + window.innerHeight && currentView == "list") {
         loadMoreTasks();
     }
 })
@@ -201,7 +201,7 @@ function loadMoreTasks() {
                         taskGroup = response;
                         displayTasks(true);
                     });
-        } else if (!document.getElementById("no-more-tasks")) {
+        } else if (!document.getElementById("no-more-tasks") && document.getElementById("no-tasks-message").style.display == "none") {
             let noMoreTasksDiv = document.createElement("div");
             noMoreTasksDiv.setAttribute("id", "no-more-tasks");
             noMoreTasksDiv.classList.add("results-message");
@@ -429,8 +429,11 @@ function getTasksForUserLocation() {
     
         // initialize map
         map = new google.maps.Map(document.getElementById("tasks-map"), {
+            mapTypeControl: false,
+            streetViewControl: false,
+            fullscreenControl: false,
             center: {lat: GOOGLE_KIRKLAND_LAT, lng: GOOGLE_KIRKLAND_LNG},
-            zoom: 13,
+            zoom: 12,
             styles: [
                 {
                     "elementType": "geometry",

--- a/src/main/webapp/homepage_script.js
+++ b/src/main/webapp/homepage_script.js
@@ -26,6 +26,10 @@ let markersMap = new Map();
 let infoWindows = [];
 let taskGroup = null;
 
+let loadMoreTasksControlNode = document.createElement("div");
+loadMoreTasksControlNode.setAttribute("id", "load-more-tasks-node");
+loadMoreTasksControlNode.index = 1;
+
 /* Changes navbar background upon resize */
 window.addEventListener("resize", function() {
     let navbar = document.getElementsByTagName("nav")[0];
@@ -184,6 +188,7 @@ function loadMoreTasks() {
                 .then(response => {
                         taskGroup = response;
                         displayTasks(true);
+                        taskGroup.tasks.forEach(task => displayTaskMarker(task));
                     });
         } else if (!document.getElementById("no-more-tasks")) {
             let noMoreTasksDiv = document.createElement("div");
@@ -543,6 +548,7 @@ function getTasksForUserLocation() {
             ],
         });
         map.setTilt(45);
+
         map.addListener('dragend', function() {
             previousNeighborhood = [...neighborhood];
             toNeighborhood(map.getCenter().toJSON()).then(() => {
@@ -605,6 +611,7 @@ function callEndOfInitFunctions() {
 function SearchNeighborhoodMapControl(controlNode) {
     const controlUI = document.createElement("div");
     controlUI.setAttribute("id", "search-area-control");
+    controlUI.className = "map-control";
     controlUI.title = "Click to search current neighborhood";
     controlUI.textContent = "Search current neighborhood";
     controlNode.appendChild(controlUI);
@@ -616,6 +623,18 @@ function SearchNeighborhoodMapControl(controlNode) {
                     taskGroup.tasks.forEach(task => displayTaskMarker(task));
                     controlNode.remove();
                 })
+    });
+}
+
+function LoadMoreTasksControl(controlNode) {
+    const controlUI = document.createElement("div");
+    controlUI.setAttribute("id", "load-more-tasks-control");
+    controlUI.className = "map-control";
+    controlUI.title = "Click to load more tasks";
+    controlUI.textContent = "Load more tasks";
+    controlNode.appendChild(controlUI);
+    controlUI.addEventListener("click", function() {
+        loadMoreTasks();
     });
 }
 
@@ -705,6 +724,13 @@ function displayTasks(append) {
 
     if (taskGroup !== null && taskGroup.currentTaskCount > 0) {
         document.getElementById("no-tasks-message").style.display = "none";
+
+        if (!taskGroup.endOfQuery && !taskMap.contains(loadMoreTasksControlNode)) {
+            new LoadMoreTasksControl(loadMoreTasksControlNode);
+            map.controls[google.maps.ControlPosition.BOTTOM_CENTER].push(loadMoreTasksControlNode);
+        } else if (taskGroup.endOfQuery && taskMap.contains(loadMoreTasksControlNode)) {
+            loadMoreTasksControlNode.remove();
+        }
 
         if (!append) {
             taskList.innerHTML = "";

--- a/src/main/webapp/homepage_script.js
+++ b/src/main/webapp/homepage_script.js
@@ -750,6 +750,7 @@ function displayTasks(append) {
             marker.setMap(null);
         });
         markersMap.clear();     
+        taskList.innerHTML = "";
     }
 
     if (taskGroup !== null && taskGroup.currentTaskCount > 0) {

--- a/src/main/webapp/homepage_script.js
+++ b/src/main/webapp/homepage_script.js
@@ -100,6 +100,31 @@ function addUIClickHandlers() {
 
     // adds closeTaskInfoModal click event
     document.getElementById("task-info-close-button").addEventListener("click", closeTaskInfoModal);
+
+    document.getElementsByClassName("view-option")[0].addEventListener("click", function(e) {
+        switchView(e.target);
+    });
+    document.getElementsByClassName("view-option")[1].addEventListener("click", function(e) {
+        switchView(e.target);
+    });
+}
+
+function switchView(element) {
+    let buttonElement;
+    if (element.classList.contains("fas")) {
+        buttonElement = element.parentNode;
+    } else {
+        buttonElement = element;
+    }
+    document.getElementById("selected-view").removeAttribute("id");
+    buttonElement.setAttribute("id", "selected-view");
+    if (buttonElement.value == "map") {
+        document.getElementById("tasks-list").style.display = "none";
+        document.getElementById("tasks-map").style.display = "block";
+    } else {
+        document.getElementById("tasks-map").style.display = "none";
+        document.getElementById("tasks-list").style.display = "block";
+    }
 }
 
 /* Function loads ten more tasks if there are any more, otherwise it displays a message saying there are no more tasks */

--- a/src/main/webapp/homepage_script.js
+++ b/src/main/webapp/homepage_script.js
@@ -24,7 +24,6 @@ let currentCategory = "all";
 let currentView = "list";
 let markersMap = new Map();
 let infoWindows = [];
-let infoWindowsOpened = 0;
 let taskGroup = null;
 
 /* Changes navbar background upon resize */
@@ -556,6 +555,12 @@ function getTasksForUserLocation() {
                 } 
             });
         });
+        // closes info windows if user clicks anywhere else on the map
+        map.addListener("click", (event) => {
+            infoWindows.forEach(infoWindow => {
+                    infoWindow.close();
+                });
+        });
 
         oms = new OverlappingMarkerSpiderfier(map, {
             markersWontMove: true,
@@ -801,7 +806,6 @@ function displayTaskMarker(task) {
 
         const infoWindow = new google.maps.InfoWindow;
         infoWindow.addListener("closeclick", () => {
-            infoWindowsOpened--;
         });
 
         const geocoder = new google.maps.Geocoder;
@@ -848,7 +852,6 @@ function openInfoWindow(map, marker, infoWindow) {
     infoWindow.setContent(windowNode);
     infoWindow.open(map, marker);
     infoWindows.push(infoWindow);
-    infoWindowsOpened++;
 }
 
 /* Function adds all the necessary tasks 'click' event listeners*/

--- a/src/main/webapp/homepage_script.js
+++ b/src/main/webapp/homepage_script.js
@@ -23,9 +23,9 @@ let userActualLocation = null;
 let currentCategory = "all";
 let currentView = "list";
 let markersMap = new Map();
+let markersToHide = new Map();
 let infoWindows = [];
 let taskGroup = null;
-let markersToHide = new Map();
 
 /* Changes navbar background upon resize */
 window.addEventListener("resize", function() {
@@ -846,6 +846,9 @@ function displayTaskMarker(task) {
 
         const geocoder = new google.maps.Geocoder;
         marker.addListener("spider_click", () => {
+            infoWindows.forEach(infoWindow => {
+                    infoWindow.close();
+                });
             openInfoWindow(map, marker, infoWindow);
         });
         oms.addMarker(marker);

--- a/src/main/webapp/homepage_script.js
+++ b/src/main/webapp/homepage_script.js
@@ -113,29 +113,70 @@ function addUIClickHandlers() {
     });
 }
 
+/* Function implements switch view (to map or to list) click functionality */
 function switchView(element) {
-    let buttonElement;
+    let buttonElement = element;
+
+    // If element clicked was icon inside the parent div, it gets the parent div
     if (element.classList.contains("fas")) {
         buttonElement = element.parentNode;
-    } else {
-        buttonElement = element;
     }
+
     document.getElementById("selected-view").removeAttribute("id");
     buttonElement.setAttribute("id", "selected-view");
-    if (buttonElement.value == "map") {
-        document.getElementById("tasks-list").style.display = "none";
-        document.getElementById("tasks-map").style.display = "block";
-        currentView = "map";
-        map.setCenter(userLocation);
-        taskGroup.tasks.forEach(task => displayTaskMarker(task));
+    const loadingElement = document.getElementById("loading");
 
-    } else {
-        document.getElementById("tasks-map").style.display = "none";
-        document.getElementById("tasks-list").style.display = "block";
-        currentView = "list";
+    // Switch to Map view
+    if (buttonElement.value == "map") {
+        // if loading has finished, it switches views
+        if (loadingElement.style.display == "none") switchToMap();
+        // otherwise it creates a mutation observer that will call switchToMap once loading is complete
+        else {
+            let observer = new MutationObserver(function(mutations) {
+                mutations.forEach(function(mutation) {
+                    if (mutation.attributeName !== "style") return;
+                    if (loadingElement.style.display == "none") {
+                        switchToMap();
+                    }
+                });
+            });
+            observer.observe(document.getElementById("loading"), {attributes: true});
+        }
+
+    // Switch to List View
+    } else if (buttonElement.value == "list") {
+         // if loading has finished, it switches views
+        if (loadingElement.style.display == "none") switchToList();
+        // otherwise it creates a mutation observer that will call switchToList once loading is complete
+        else {
+            let observer = new MutationObserver(function(mutations) {
+                mutations.forEach(function(mutation) {
+                    if (mutation.attributeName !== "style") return;
+                    if (loadingElement.style.display == "none") {
+                        switchToList();
+                    }
+                });
+            });
+            observer.observe(document.getElementById("loading"), {attributes: true});
+        }
     }
 }
 
+/* Helper function that switches to map view */
+function switchToMap() {
+    document.getElementById("tasks-list").style.display = "none";
+    document.getElementById("tasks-map").style.display = "block";
+    currentView = "map";
+    map.setCenter(userLocation);
+    taskGroup.tasks.forEach(task => displayTaskMarker(task));
+}
+
+/* Helper function that switches to list view */
+function switchToList() {
+    document.getElementById("tasks-map").style.display = "none";
+    document.getElementById("tasks-list").style.display = "block";
+    currentView = "list";
+}
 /* Function loads ten more tasks if there are any more, otherwise it displays a message saying there are no more tasks */
 function loadMoreTasks() {
     if (userNeighborhoodIsKnown()) {

--- a/src/main/webapp/homepage_style.css
+++ b/src/main/webapp/homepage_style.css
@@ -299,10 +299,35 @@ section {
   padding-top: 1em;
 }
 
+#tasks-map-wrapper {
+  position: relative;
+  box-shadow: 0 0 1px 1px rgba(0, 0, 0, 0.18);
+  display: none;
+}
+
 #tasks-map { 
   height: calc(100vh - 330px);
   max-height: 70vh;
-  display: none;
+}
+
+#confirm-wrapper {
+  display: table;
+  position: absolute;
+  width: 100%;
+  line-height: 1em;
+}
+
+#confirm-map {
+  display: table-cell;
+  vertical-align: middle;
+  text-align: center;
+}
+
+#exit-help-map {
+  font-size: 30px;
+  text-align: right;
+  padding-right: 1em;
+  height: calc(50% - 0.5em);
 }
 
 #search-area-control {

--- a/src/main/webapp/homepage_style.css
+++ b/src/main/webapp/homepage_style.css
@@ -305,6 +305,17 @@ section {
   display: none;
 }
 
+#search-area-control {
+  background-color: #fff;
+  color: rgb(61,61,61);
+  font-size: 14px;
+  padding: 10px 20px;
+  margin-top: 8px;
+  cursor: pointer;
+  box-shadow: 0 2px 6px rgba(0,0,0,.15);
+  -webkit-font-smoothing: antialiased;
+}
+
 /* Add modal styling */
 .modalWrapper {
   display: none; /* Hidden by default */

--- a/src/main/webapp/homepage_style.css
+++ b/src/main/webapp/homepage_style.css
@@ -300,7 +300,8 @@ section {
 }
 
 #tasks-map { 
-  height: calc(100vh - 340px);
+  height: calc(100vh - 330px);
+  max-height: 70vh;
   display: none;
 }
 
@@ -508,7 +509,7 @@ td {
   }
 
   #tasks-map {
-    height: calc(100vh - 320px);
+    height: calc(100vh - 300px);
   }
 }
 

--- a/src/main/webapp/homepage_style.css
+++ b/src/main/webapp/homepage_style.css
@@ -229,8 +229,13 @@ section {
   padding: 1em;
 }
 
+.task-content-marker {
+  padding: 1em 0;
+}
+
 .user-nickname {
   width: 70%;
+  font-weight: bold;
 }
 
 .help-out {
@@ -247,12 +252,15 @@ section {
 }
 
 .task-footer {
-  font-style: italic;
   display: flex;
   justify-content: space-between;
   padding-left: 1em;
   padding-bottom: 1em;
   padding-right: 1em;
+}
+
+.task-category {
+  font-style: italic;
 }
 
 .task-date-time {
@@ -277,6 +285,10 @@ section {
 .help-overlay a:hover {
   color: gray;
   cursor: pointer;
+}
+
+.help-out-marker {
+  margin-top: 0.5em;
 }
 
 .exit-help {

--- a/src/main/webapp/homepage_style.css
+++ b/src/main/webapp/homepage_style.css
@@ -305,7 +305,7 @@ section {
   display: none;
 }
 
-#tasks-map { 
+#tasks-map {
   height: calc(100vh - 330px);
   max-height: 70vh;
 }
@@ -337,11 +337,11 @@ section {
 
 .map-control {
   background-color: #fff;
-  color: rgb(61,61,61);
+  color: rgb(61, 61, 61);
   font-size: 14px;
   padding: 10px 20px;
   cursor: pointer;
-  box-shadow: 0 2px 6px rgba(0,0,0,.15);
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.15);
   -webkit-font-smoothing: antialiased;
 }
 
@@ -518,9 +518,9 @@ td {
     font-size: 2.5em;
   }
 
-  #place-input { 
+  #place-input {
     display: block;
-   }
+  }
 
   #search-box {
     padding-top: 0;

--- a/src/main/webapp/homepage_style.css
+++ b/src/main/webapp/homepage_style.css
@@ -330,6 +330,11 @@ section {
   height: calc(50% - 0.5em);
 }
 
+#map-control-wrapper {
+  display: flex;
+  justify-content: center;
+}
+
 .map-control {
   background-color: #fff;
   color: rgb(61,61,61);
@@ -345,7 +350,11 @@ section {
 }
 
 #load-more-tasks-control {
-  margin-bottom: 8px;
+  text-align: center;
+  margin-top: -3em;
+  position: absolute;
+  z-index: 4;
+  display: none;
 }
 
 /* Add modal styling */

--- a/src/main/webapp/homepage_style.css
+++ b/src/main/webapp/homepage_style.css
@@ -561,7 +561,7 @@ td {
   }
 
   #tasks-map {
-    height: calc(100vh - 300px);
+    height: calc(100vh - 450px);
   }
 }
 

--- a/src/main/webapp/homepage_style.css
+++ b/src/main/webapp/homepage_style.css
@@ -111,7 +111,6 @@ section {
 #control-bar-message-wrapper {
   background-image: linear-gradient(to bottom, white 90%, transparent);
   position: sticky;
-  padding-top: 1em;
   top: 0;
   width: 101%;
   z-index: 2;
@@ -262,6 +261,11 @@ section {
   text-align: right;
   padding-right: 1em;
   padding-top: 1em;
+}
+
+#tasks-map { 
+  height: calc(100vh - 340px);
+  display: none;
 }
 
 /* Add modal styling */
@@ -461,6 +465,10 @@ td {
   nav {
     padding-bottom: 0;
     background-color: white;
+  }
+
+  #tasks-map {
+    height: calc(100vh - 320px);
   }
 }
 

--- a/src/main/webapp/homepage_style.css
+++ b/src/main/webapp/homepage_style.css
@@ -103,9 +103,34 @@ section {
   padding-bottom: 0.5em;
 }
 
-#search-box {
+#search-and-view-wrapper {
+  display: flex;
+  justify-content: space-between;
   padding: 0.5em 0.5em 1em 0.5em;
-  visibility: hidden;
+}
+
+#search-box {
+  padding-top: 0.4em;
+}
+
+#list-map-view {
+  display: flex;
+}
+
+.view-option {
+  border: solid 1px #bbb;
+  background-color: #eee;
+  font-size: 1.2em;
+  padding: 0.2em 0.5em 0.2em 0.5em;
+  margin-right: -0.5px;
+}
+
+#selected-view {
+  background-color: #bbb;
+}
+
+#selected-view:hover > i {
+  color: #222;
 }
 
 #control-bar-message-wrapper {
@@ -173,7 +198,6 @@ section {
 
 #loading {
   display: block;
-  margin-top: -2em;
 }
 
 #tasks-list {
@@ -421,21 +445,25 @@ td {
   #add-task {
     text-align: right;
     padding-right: 0.5em;
-    margin-top: -1em;
+    margin-top: -1.3em;
+    padding-bottom: 0.2em;
   }
 
   #addtaskbutton {
     font-size: 2.5em;
   }
 
-  #search-box {
-    padding-top: 0;
-    margin-top: -0.5em;
-  }
-
   #place-input { 
     display: block;
-   } 
+   }
+
+  #search-box {
+    padding-top: 0;
+  }
+
+  #list-map-view {
+    margin: 0.5em 0;
+  }
 
   .results-message {
     width: 95%;

--- a/src/main/webapp/homepage_style.css
+++ b/src/main/webapp/homepage_style.css
@@ -353,7 +353,7 @@ section {
   text-align: center;
   margin-top: -3em;
   position: absolute;
-  z-index: 4;
+  z-index: 3;
   display: none;
 }
 
@@ -361,7 +361,7 @@ section {
 .modalWrapper {
   display: none; /* Hidden by default */
   position: fixed; /* Stay in place */
-  z-index: 3; /* Sit on top */
+  z-index: 4; /* Sit on top */
   left: 0;
   top: 0;
   width: 100%; /* Full width */

--- a/src/main/webapp/homepage_style.css
+++ b/src/main/webapp/homepage_style.css
@@ -330,15 +330,22 @@ section {
   height: calc(50% - 0.5em);
 }
 
-#search-area-control {
+.map-control {
   background-color: #fff;
   color: rgb(61,61,61);
   font-size: 14px;
   padding: 10px 20px;
-  margin-top: 8px;
   cursor: pointer;
   box-shadow: 0 2px 6px rgba(0,0,0,.15);
   -webkit-font-smoothing: antialiased;
+}
+
+#search-area-control {
+  margin-top: 8px;
+}
+
+#load-more-tasks-control {
+  margin-bottom: 8px;
 }
 
 /* Add modal styling */

--- a/src/main/webapp/index.jsp
+++ b/src/main/webapp/index.jsp
@@ -159,7 +159,7 @@
                 <textarea name="task-detail-input" id="task-detail-input" placeholder="Describe your task here:"></textarea>
                 <br/><br/>
                 <label for="rewarding-point-input">Rewarding Points<span class="req">*</span></label>
-                <input type="number" id="rewarding-point-input" name="reward-input" min="0" max="200" value="50">
+                <input type="number" id="reward-input" name="reward-input" min="0" max="200" value="50">
                 <br/><br/>
                 <label for="category-input">Task Category<span class="req">*</span></label>
                 <select name="category-input" id="category-input" form="new-task-form">

--- a/src/main/webapp/index.jsp
+++ b/src/main/webapp/index.jsp
@@ -136,7 +136,17 @@
           <!--Listed Tasks Container-->
           <div id="tasks-list"></div>
           <!--Map Tasks Container-->
-          <div id="tasks-map"></div>
+          <div id="tasks-map-wrapper">
+              <div class="help-overlay" id="help-overlay-map">
+                  <div id="exit-help-map"><a>&times</a></div>
+                  <div id="confirm-wrapper">
+                      <a class="confirm-help" id="confirm-map">
+                          CONFIRM
+                      </a>
+                  </div>
+              </div>
+            <div id="tasks-map"></div>
+          </div>
       </section>
       <!--Create Tasks Modal-->
       <div class="modalWrapper" id="createTaskModalWrapper">

--- a/src/main/webapp/index.jsp
+++ b/src/main/webapp/index.jsp
@@ -112,8 +112,12 @@
                     <input id="place-input" name="place-input" type="text" placeholder=" Type an address here" class="pac-target-input" autocomplete="off">
                 </div>
                 <div id="list-map-view">
-                    <div id="selected-view" class="view-option" aria-label="List View"><i class="fas fa-list" aria-hidden="true"></i></div>
-                    <div class="view-option" aria-label="Map View"><i class="fas fa-map" aria-hidden="true"></i></div>
+                    <button id="selected-view" value="list" class="view-option" aria-label="List View">
+                        <i class="fas fa-list" aria-hidden="true"></i>
+                    </button>
+                    <button class="view-option" value="map" aria-label="Map View">
+                        <i class="fas fa-map" aria-hidden="true"></i>
+                    </button>
                 </div>
               </div>
 

--- a/src/main/webapp/index.jsp
+++ b/src/main/webapp/index.jsp
@@ -121,6 +121,7 @@
                         <i class="fas fa-map" aria-hidden="true"></i>
                     </button>
                 </div>
+              </div>
 
               <!--Results Messages-->
               <div id="loading" class="results-message">

--- a/src/main/webapp/index.jsp
+++ b/src/main/webapp/index.jsp
@@ -22,6 +22,7 @@
     <title>NeighborGood</title>
     <link rel="stylesheet" href="homepage_style.css">
     <script type='text/javascript' src='config.js'></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/OverlappingMarkerSpiderfier/1.0.3/oms.min.js"></script>
     <script src="homepage_script.js"></script>
     <script src="https://kit.fontawesome.com/71105f4105.js" crossorigin="anonymous"></script> 
   </head>

--- a/src/main/webapp/index.jsp
+++ b/src/main/webapp/index.jsp
@@ -130,7 +130,7 @@
                   We could not retrieve your location to display your neighborhood tasks.
               </div>
               <div id="no-tasks-message" class="results-message">
-                  Sorry, there are currently no tasks within your neighborhood for you to help with.
+                  Sorry, there are currently no tasks within the neighborhood for you to help with.
               </div>
           </div>
           <!--Listed Tasks Container-->

--- a/src/main/webapp/index.jsp
+++ b/src/main/webapp/index.jsp
@@ -22,6 +22,7 @@
     <title>NeighborGood</title>
     <link rel="stylesheet" href="homepage_style.css">
     <script type='text/javascript' src='config.js'></script>
+    <script type='text/javascript' src='map_styles.js'></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/OverlappingMarkerSpiderfier/1.0.3/oms.min.js"></script>
     <script src="homepage_script.js"></script>
     <script src="https://kit.fontawesome.com/71105f4105.js" crossorigin="anonymous"></script>

--- a/src/main/webapp/index.jsp
+++ b/src/main/webapp/index.jsp
@@ -105,6 +105,7 @@
                   }
                   %>
               </div>
+              <!--Search By Different Location Input-->
               <div id="search-box">
                 <label for="place-input">Search tasks in a different location:</label>
                 <input id="place-input" name="place-input" type="text" placeholder=" Type an address here" class="pac-target-input" autocomplete="off">
@@ -126,6 +127,8 @@
           </div>
           <!--Listed Tasks Container-->
           <div id="tasks-list"></div>
+          <!--Map Tasks Container-->
+          <div id="tasks-map"></div>
       </section>
       <!--Create Tasks Modal-->
       <div class="modalWrapper" id="createTaskModalWrapper">

--- a/src/main/webapp/index.jsp
+++ b/src/main/webapp/index.jsp
@@ -105,10 +105,16 @@
                   }
                   %>
               </div>
-              <!--Search By Different Location Input-->
-              <div id="search-box">
-                <label for="place-input">Search tasks in a different location:</label>
-                <input id="place-input" name="place-input" type="text" placeholder=" Type an address here" class="pac-target-input" autocomplete="off">
+              <div id="search-and-view-wrapper">
+                <!--Search By Different Location Input-->
+                <div id="search-box">
+                    <label for="place-input">Search from a different location:</label>
+                    <input id="place-input" name="place-input" type="text" placeholder=" Type an address here" class="pac-target-input" autocomplete="off">
+                </div>
+                <div id="list-map-view">
+                    <div id="selected-view" class="view-option" aria-label="List View"><i class="fas fa-list" aria-hidden="true"></i></div>
+                    <div class="view-option" aria-label="Map View"><i class="fas fa-map" aria-hidden="true"></i></div>
+                </div>
               </div>
 
               <!--Results Messages-->
@@ -117,9 +123,6 @@
               </div>
               <div id="location-missing-message" class="results-message">
                   We could not retrieve your location to display your neighborhood tasks.
-              </div>
-              <div id="tasks-message" class="results-message">
-                  These are the most recent tasks in your neighborhood:
               </div>
               <div id="no-tasks-message" class="results-message">
                   Sorry, there are currently no tasks within your neighborhood for you to help with.

--- a/src/main/webapp/index.jsp
+++ b/src/main/webapp/index.jsp
@@ -146,6 +146,11 @@
                   </div>
               </div>
             <div id="tasks-map"></div>
+            <div id="map-control-wrapper">
+                <div class="map-control" id="load-more-tasks-control">
+                    Load more tasks
+                </div>
+            </div>
           </div>
       </section>
       <!--Create Tasks Modal-->

--- a/src/main/webapp/map_styles.js
+++ b/src/main/webapp/map_styles.js
@@ -1,0 +1,134 @@
+let styles = [
+                {
+                    "elementType": "geometry",
+                    "stylers": [{"color": "#ebe3cd"}]
+                },
+                {
+                    "elementType": "labels.text.fill",
+                    "stylers": [{"color": "#523735"}]
+                },
+                {
+                    "elementType": "labels.text.stroke",
+                    "stylers": [{"color": "#f5f1e6"}]
+                },
+                {
+                    "featureType": "administrative",
+                    "elementType": "geometry.stroke",
+                    "stylers": [{"color": "#c9b2a6"}]
+                },
+                {
+                    "featureType": "administrative.land_parcel",
+                    "elementType": "geometry.stroke",
+                    "stylers": [{"color": "#dcd2be"}]
+                },
+                {
+                    "featureType": "administrative.land_parcel",
+                    "elementType": "labels.text.fill",
+                    "stylers": [{"color": "#ae9e90"}]
+                },
+                {
+                    "featureType": "landscape.man_made",
+                    "elementType": "geometry.stroke",
+                    "stylers": [{"color": "#36aff9"}]
+                },
+                {
+                    "featureType": "landscape.natural",
+                    "elementType": "geometry",
+                    "stylers": [{"color": "#dfd2ae"}]
+                },
+                {
+                    "featureType": "poi",
+                    "elementType": "geometry",
+                    "stylers": [{"color": "#dfd2ae"}]
+                },
+                {
+                    "featureType": "poi",
+                    "elementType": "labels.text.fill",
+                    "stylers": [{"color": "#93817c"}]
+                },
+                {
+                    "featureType": "poi.park",
+                    "elementType": "geometry.fill",
+                    "stylers": [{"color": "#a5b076"}]
+                },
+                {
+                    "featureType": "poi.park",
+                    "elementType": "labels.text.fill",
+                    "stylers": [{"color": "#28c4fa"}, {"lightness": -5}, {"weight": 2}]
+                },
+                {
+                    "featureType": "poi.park",
+                    "elementType": "labels.text.stroke",
+                    "stylers": [{"color": "#f9fcc7"}]
+                },
+                {
+                    "featureType": "road",
+                    "elementType": "geometry",
+                    "stylers": [{"color": "#f5f1e6"}]
+                },
+                {
+                    "featureType": "road.arterial",
+                    "elementType": "geometry",
+                    "stylers": [{"color": "#fdfcf8"}]
+                },
+                {
+                    "featureType": "road.highway",
+                    "elementType": "geometry",
+                    "stylers": [{"color": "#f8c967"}]
+                },
+                {
+                    "featureType": "road.highway",
+                    "elementType": "geometry.stroke",
+                    "stylers": [{"color": "#f2756a"}]
+                },
+                {
+                    "featureType": "road.highway",
+                    "elementType": "labels.text.fill",
+                    "stylers": [{"color": "#f98357"}]
+                },
+                {
+                    "featureType": "road.highway.controlled_access",
+                    "elementType": "geometry",
+                    "stylers": [{"color": "#e98d58"}]
+                },
+                {
+                    "featureType": "road.highway.controlled_access",
+                    "elementType": "geometry.stroke",
+                    "stylers": [{"color": "#db8555"}]
+                },
+                {
+                    "featureType": "road.local",
+                    "elementType": "labels.text.fill",
+                    "stylers": [{"color": "#806b63"}]
+                },
+                {
+                    "featureType": "transit.line",
+                    "elementType": "geometry",
+                    "stylers": [{"color": "#dfd2ae"}]
+                },
+                {
+                    "featureType": "transit.line",
+                    "elementType": "labels.text.fill",
+                    "stylers": [{"color": "#8f7d77"}]
+                },
+                {
+                    "featureType": "transit.line",
+                    "elementType": "labels.text.stroke",
+                    "stylers": [{"color": "#ebe3cd"}]
+                },
+                {
+                    "featureType": "transit.station",
+                    "elementType": "geometry",
+                    "stylers": [{"color": "#dfd2ae"}]
+                },
+                {
+                    "featureType": "water",
+                    "elementType": "geometry.fill",
+                    "stylers": [{"color": "#65d3f9"}, {"saturation": -10},  {"lightness": 10}]
+                },
+                {
+                    "featureType": "water",
+                    "elementType": "labels.text.fill",
+                    "stylers": [{"color": "#92998d"}]
+                }
+            ]

--- a/src/main/webapp/user_profile.jsp
+++ b/src/main/webapp/user_profile.jsp
@@ -185,7 +185,7 @@
                 </div>
                 <br/>
                 <textarea name="address-input" id="edit-address-input"></textarea>
-                <p id="rest-map">Click to mark your personal address on the map!</p>
+                <p id="rest-map">Click to mark your personal address on the map!<span class="req">*</span></p>
                 <input id="place-input" class="controls" type="text" placeholder="Search Box">
                 <div id="map"></div>
                 <br/><br/>
@@ -209,6 +209,8 @@
                 </div>
                 <br/>
                 <input type="text" name="phone-input" id="edit-phone-number-input">
+                <input type="hidden" name="lat" id="lat-input">
+                <input type="hidden" name="lng" id="lng-input">
                 <br/>
                 <br/>
                 <input type="submit"/>

--- a/src/main/webapp/user_profile.jsp
+++ b/src/main/webapp/user_profile.jsp
@@ -5,6 +5,7 @@
     <title>My Account</title>
     <link rel="stylesheet" href="user_profile_style.css">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
+    <script type='text/javascript' src='map_styles.js'></script>
     <script type='text/javascript' src='config.js'></script>
     <script src="user_profile_script.js"></script>
   </head>

--- a/src/main/webapp/user_profile_script.js
+++ b/src/main/webapp/user_profile_script.js
@@ -17,6 +17,7 @@ var map;
 const GOOGLE_KIRKLAND_LAT = 47.669846;
 const GOOGLE_KIRKLAND_LNG = -122.1996099;
 const MAPSKEY = config.MAPS_KEY;
+const MAP_STYLE = styles;
 
 function validateTaskForm(id) {
     var result = true;
@@ -463,140 +464,7 @@ async function initMap() {
         map = new google.maps.Map(document.getElementById("map"), {
             center: {lat: GOOGLE_KIRKLAND_LAT, lng: GOOGLE_KIRKLAND_LNG},
             zoom: 18,
-            styles: [
-                {
-                    "elementType": "geometry",
-                    "stylers": [{"color": "#ebe3cd"}]
-                },
-                {
-                    "elementType": "labels.text.fill",
-                    "stylers": [{"color": "#523735"}]
-                },
-                {
-                    "elementType": "labels.text.stroke",
-                    "stylers": [{"color": "#f5f1e6"}]
-                },
-                {
-                    "featureType": "administrative",
-                    "elementType": "geometry.stroke",
-                    "stylers": [{"color": "#c9b2a6"}]
-                },
-                {
-                    "featureType": "administrative.land_parcel",
-                    "elementType": "geometry.stroke",
-                    "stylers": [{"color": "#dcd2be"}]
-                },
-                {
-                    "featureType": "administrative.land_parcel",
-                    "elementType": "labels.text.fill",
-                    "stylers": [{"color": "#ae9e90"}]
-                },
-                {
-                    "featureType": "landscape.man_made",
-                    "elementType": "geometry.stroke",
-                    "stylers": [{"color": "#36aff9"}]
-                },
-                {
-                    "featureType": "landscape.natural",
-                    "elementType": "geometry",
-                    "stylers": [{"color": "#dfd2ae"}]
-                },
-                {
-                    "featureType": "poi",
-                    "elementType": "geometry",
-                    "stylers": [{"color": "#dfd2ae"}]
-                },
-                {
-                    "featureType": "poi",
-                    "elementType": "labels.text.fill",
-                    "stylers": [{"color": "#93817c"}]
-                },
-                {
-                    "featureType": "poi.park",
-                    "elementType": "geometry.fill",
-                    "stylers": [{"color": "#a5b076"}]
-                },
-                {
-                    "featureType": "poi.park",
-                    "elementType": "labels.text.fill",
-                    "stylers": [{"color": "#28c4fa"}, {"lightness": -5}, {"weight": 2}]
-                },
-                {
-                    "featureType": "poi.park",
-                    "elementType": "labels.text.stroke",
-                    "stylers": [{"color": "#f9fcc7"}]
-                },
-                {
-                    "featureType": "road",
-                    "elementType": "geometry",
-                    "stylers": [{"color": "#f5f1e6"}]
-                },
-                {
-                    "featureType": "road.arterial",
-                    "elementType": "geometry",
-                    "stylers": [{"color": "#fdfcf8"}]
-                },
-                {
-                    "featureType": "road.highway",
-                    "elementType": "geometry",
-                    "stylers": [{"color": "#f8c967"}]
-                },
-                {
-                    "featureType": "road.highway",
-                    "elementType": "geometry.stroke",
-                    "stylers": [{"color": "#f2756a"}]
-                },
-                {
-                    "featureType": "road.highway",
-                    "elementType": "labels.text.fill",
-                    "stylers": [{"color": "#f98357"}]
-                },
-                {
-                    "featureType": "road.highway.controlled_access",
-                    "elementType": "geometry",
-                    "stylers": [{"color": "#e98d58"}]
-                },
-                {
-                    "featureType": "road.highway.controlled_access",
-                    "elementType": "geometry.stroke",
-                    "stylers": [{"color": "#db8555"}]
-                },
-                {
-                    "featureType": "road.local",
-                    "elementType": "labels.text.fill",
-                    "stylers": [{"color": "#806b63"}]
-                },
-                {
-                    "featureType": "transit.line",
-                    "elementType": "geometry",
-                    "stylers": [{"color": "#dfd2ae"}]
-                },
-                {
-                    "featureType": "transit.line",
-                    "elementType": "labels.text.fill",
-                    "stylers": [{"color": "#8f7d77"}]
-                },
-                {
-                    "featureType": "transit.line",
-                    "elementType": "labels.text.stroke",
-                    "stylers": [{"color": "#ebe3cd"}]
-                },
-                {
-                    "featureType": "transit.station",
-                    "elementType": "geometry",
-                    "stylers": [{"color": "#dfd2ae"}]
-                },
-                {
-                    "featureType": "water",
-                    "elementType": "geometry.fill",
-                    "stylers": [{"color": "#65d3f9"}, {"saturation": -10},  {"lightness": 10}]
-                },
-                {
-                    "featureType": "water",
-                    "elementType": "labels.text.fill",
-                    "stylers": [{"color": "#92998d"}]
-                }
-            ],
+            styles: MAP_STYLE,
         });
         map.setTilt(45);
 

--- a/src/main/webapp/user_profile_script.js
+++ b/src/main/webapp/user_profile_script.js
@@ -42,19 +42,25 @@ function validateTaskForm(id) {
 function validateInfoForm(id) {
     var result = true;
     var form = document.getElementById(id);
-    var inputName = ["nickname", "address", "zipcode", "country", "phone"];
+    var inputName = ["nickname", "address", "zipcode", "country", "phone", "lat", "lng"];
     for (var i = 0; i < inputName.length; i++) {
         var name = inputName[i];
         var inputField = form[name.concat("-input")].value.trim();
         if (inputField === "") {
             result = false;
             form[name.concat("-input")].classList.add("highlight");
+            if (inputName[i] === "lat" || inputName[i] === "lng") {
+                document.getElementById("map").classList.add("highlight");
+            }
         } else {
             form[name.concat("-input")].classList.remove("highlight");
+            if (inputName[i] === "lat" || inputName[i] === "lng") {
+                document.getElementById("map").classList.remove("highlight");
+            }
         }
     }
     if (!result) {
-        alert("All fields are required. Please fill out all fields with non-empty input.");
+        alert("All fields are required. Please fill out all fields with non-empty input and mark your personal address on the map.");
         return false;
     }
     return true;
@@ -683,6 +689,9 @@ function displayMarker(position) {
     markers = [];
     markers.push(marker);
 
+    document.getElementById("lat-input").value = position.lat();
+    document.getElementById("lng-input").value = position.lng();
+
     return marker;
 }
 
@@ -696,6 +705,8 @@ function deleteMarker(latitude, longitude) {
             return false;
         }
     });
+    document.getElementById("lat-input").value = '';
+    document.getElementById("lng-input").value = '';
 }
 
 function geocodeLatLng(geocoder, map, infowindow, position, marker) {

--- a/src/main/webapp/user_profile_style.css
+++ b/src/main/webapp/user_profile_style.css
@@ -254,7 +254,6 @@ table button:hover i {
 }
 
 #map {
-  border: thin solid black;
   height: 400px;
   max-width: 100%;
 }

--- a/src/test/java/com/google/neighborgood/UserInfoServletTest.java
+++ b/src/test/java/com/google/neighborgood/UserInfoServletTest.java
@@ -102,6 +102,8 @@ public final class UserInfoServletTest {
     when(request.getParameter("phone-input")).thenReturn("4xxxxxxxxx");
     when(request.getParameter("zipcode-input")).thenReturn("xxxxx");
     when(request.getParameter("country-input")).thenReturn("United States");
+    when(request.getParameter("lat")).thenReturn("47.6912892");
+    when(request.getParameter("lng")).thenReturn("-122.2406845");
 
     new UserInfoServlet().doPost(request, response);
 
@@ -174,6 +176,8 @@ public final class UserInfoServletTest {
     when(request.getParameter("phone-input")).thenReturn("4xxxxxxxxx");
     when(request.getParameter("zipcode-input")).thenReturn("xxxxx");
     when(request.getParameter("country-input")).thenReturn("United States");
+    when(request.getParameter("lat")).thenReturn("47.6912892");
+    when(request.getParameter("lng")).thenReturn("-122.2406845");
 
     new UserInfoServlet().doPost(request, response);
 
@@ -199,6 +203,8 @@ public final class UserInfoServletTest {
     assertEquals("United States", (String) entity.getProperty("country"));
     assertEquals("leonardzhang@google.com", (String) entity.getProperty("email"));
     assertEquals("1234567890", entity.getKey().getName());
+    assertEquals("47.6912892", String.valueOf(entity.getProperty("lat")));
+    assertEquals("-122.2406845", String.valueOf(entity.getProperty("lng")));
     assertEquals(0, (long) entity.getProperty("points"));
 
     when(request.getParameter("nickname-input")).thenReturn("Leo");
@@ -224,6 +230,8 @@ public final class UserInfoServletTest {
     assertEquals("United States", (String) entity.getProperty("country"));
     assertEquals("leonardzhang@google.com", (String) entity.getProperty("email"));
     assertEquals("1234567890", entity.getKey().getName());
+    assertEquals("47.6912892", String.valueOf(entity.getProperty("lat")));
+    assertEquals("-122.2406845", String.valueOf(entity.getProperty("lng")));
     assertEquals(0, (long) entity.getProperty("points"));
   }
 
@@ -243,6 +251,8 @@ public final class UserInfoServletTest {
     when(request.getParameter("phone-input")).thenReturn("4xxxxxxxxx");
     when(request.getParameter("zipcode-input")).thenReturn("xxxxx");
     when(request.getParameter("country-input")).thenReturn("United States");
+    when(request.getParameter("lat")).thenReturn("47.6912892");
+    when(request.getParameter("lng")).thenReturn("-122.2406845");
 
     // Try to catch the error message sent by the UserInfoServlet
     System.setErr(new PrintStream(errContent));
@@ -318,6 +328,8 @@ public final class UserInfoServletTest {
     assertEquals("United States", (String) entity.getProperty("country"));
     assertEquals("leonardzhang@google.com", (String) entity.getProperty("email"));
     assertEquals("1234567890", entity.getKey().getName());
+    assertEquals("47.6912892", String.valueOf(entity.getProperty("lat")));
+    assertEquals("-122.2406845", String.valueOf(entity.getProperty("lng")));
     assertEquals(0, (long) entity.getProperty("points"));
   }
 


### PR DESCRIPTION
- Changes implementation of TaskServlet's doGet response so response can both be used for list view as well as map view (consequently a new createTaskListNode function was needed in the script file).
- Adds buttons to UI to toggle between map and list view.
- Loads markers per every task loaded into map (markers with exact same lat/lng coordinates will be on top of each other so open click these open up like a spider using a library I found).
- Load more button shows up if there are more tasks in the query that haven't been returned - upon pressing this, 10 more tasks are loaded into the map.
- Upon drag into a different location, the map checks if the new map center is in a different neighborhood, if so it shows the search this neighborhood control button, and upon clicking it it fetches tasks from that neighborhood.
- Markers can be clicked to see the same information available in list-view and the infowindow that opens up can be clicked to open up the task detail modal.

Resolves #29 
Resolves #77 by making use of an external map styling file.